### PR TITLE
NEW: Adds APR computation to `BaseConvexStrategy`

### DIFF
--- a/contracts/strategies/convex/ConvexBaseStrategy.sol
+++ b/contracts/strategies/convex/ConvexBaseStrategy.sol
@@ -342,6 +342,10 @@ abstract contract ConvexBaseStrategy is
         _depositInCurve(_minLpToken);
         uint256 _curveLpBalanceAfter = _curveLpToken.balanceOf(address(this));
         uint256 _gainedLpTokens = (_curveLpBalanceAfter - _curveLpBalanceBefore);
+
+        // save in _balances the amount of curveLpTokens received to use off-chain
+        _balances[_convexRewards.length + 1] = _gainedLpTokens;
+        
         if (_curveLpBalanceAfter > 0) {
             // deposit in curve and stake on convex
             _stakeConvex(_curveLpBalanceAfter);

--- a/contracts/strategies/convex/ConvexBaseStrategy.sol
+++ b/contracts/strategies/convex/ConvexBaseStrategy.sol
@@ -384,8 +384,9 @@ abstract contract ConvexBaseStrategy is
     ///      estimate (eg. computing APR using historical APR data).
     ///      Also it does not take into account compounding (APY).
     function getApr() external view override returns (uint256) {
-        // // apr = rate * 1 year / harvest interval in days (supposing 6570 blocks a day)
-        return latestPriceIncrease * (365 / (latestHarvestInterval / 6570)); 
+        // apr = rate * 1 year (in hours) / harvest interval in hours (supposing 273 blocks in an hour)
+        uint256 periods = 8760 / (latestHarvestInterval / 273);
+        return latestPriceIncrease * periods;
     }
 
     /// @return rewardTokens tokens array of reward token addresses

--- a/contracts/strategies/convex/ConvexBaseStrategy.sol
+++ b/contracts/strategies/convex/ConvexBaseStrategy.sol
@@ -374,7 +374,11 @@ abstract contract ConvexBaseStrategy is
         }
     }
 
-    /// @return returns 0, don't know if there are ways you can calculate APR on-chain for Convex
+    /// @return returns an APR estimation.
+    /// @dev values returned by this method should be taken as an imprecise estimation.
+    ///      For client integration something more complex should be done to have a more precise
+    ///      estimate (eg. computing APR using historical APR data).
+    ///      Also it does not take into account compounding (APY).
     function getApr() external view override returns (uint256) {
         // // apr = rate * 1 year / harvest interval in days (supposing 6570 blocks a day)
         return latestPriceIncrease * (365 / (latestHarvestInterval / 6570)); 


### PR DESCRIPTION
This PR enables APR view function on `BaseConvexStrategy`. Other minor fixes were applied to `redeemRewards` method.

APR is computed as `price_increase * (365 days / latest_harvest_days_interval)`.
APY can be computed as `((1e18 + price_increase) ** (365 days / latest_harvest_days_interval)) - 1e18`

eg:

**Strategy accounts a price increase of 0.002 after an harvest with an interval of 7 days (from the previous harvest)**
APR = 0.002 * (365 / 7) = 1.04%
APY = (1 + 0.002) ^ (365 / 7) - 1= 1.09%

### Technical Implementation
APR calculation is done when `getApr()` method is called. Some changes to the contract storage were necessary to store the price increase and the interval from the latest 

When `redeemRewards(bytes)` is called and the Convex Strategy deposits and stake Curve LP tokens in Convex Finance, these other variables are stored:

- `latestPriceIncrease`, computed as the total gained LP tokens divided by the total supply of strategy tokens
- `latestHarvestInterval`, computed as the difference between current block and previous harvest block

These state variables are used in `getApr()` to calculate the actual APR.

### Frontend considerations
- Values returned from `getApr()` are scaled by 1e18.
- For the frontend APR calculation, values returned from `getApr()` method should not be taken as precise estimations. Something more complex like calculating an average APR should be more precise than reading APR directly. (eg. https://github.com/yearn/yearn-exporter/blob/92d4c87198d132263720052a162958a6688d61ff/yearn/apy/v2.py#L114)