### PR TITLE
fix:rewards calculation

### DIFF
--- a/contracts/IdleCDOTrancheRewards.sol
+++ b/contracts/IdleCDOTrancheRewards.sol
@@ -191,19 +191,19 @@ contract IdleCDOTrancheRewards is Initializable, PausableUpgradeable, OwnableUpg
     uint256 _unClaimableRewards = _unClaimableRewards(_reward);
 
     // reduce the 'real' global index proportionally to the total amount staked
-    if (_totalStaked > 0 && _unClaimableRewards > 0 ) {
+    if (_totalStaked > 0 && _unClaimableRewards > 0) {
         _index -= _unClaimableRewards * ONE_TRANCHE_TOKEN / _totalStaked; 
     }
 
     // add locked rewards that users who `unstake` during the `coolingPeriod` to global index
-    if (rewardNotTransferred >0 ) {
+    if (rewardNotTransferred > 0) {
       _index += rewardNotTransferred * ONE_TRANCHE_TOKEN / _totalStaked;
     }
   }
 
-  function _unClaimableRewards(address reward) internal view returns (uint256){
+  function _unClaimableRewards(address reward) internal view returns (uint256) {
         uint256 distance = block.number - lockedRewardsLastBlock[reward];
-        if(distance < coolingPeriod) {
+        if (distance < coolingPeriod) {
           // if the cooling period has not passed, calculate the rewards that should
           // still be locked
           uint256 _lockedRewards = lockedRewards[reward];

--- a/contracts/IdleCDOTrancheRewardsStorage.sol
+++ b/contracts/IdleCDOTrancheRewardsStorage.sol
@@ -21,4 +21,7 @@ contract IdleCDOTrancheRewardsStorage {
   uint256 public totalStaked;
   // number of blocks during which rewards will be released for stakers
   uint256 public coolingPeriod;
+  // amount of reward that users who `unstake` will not receive. 
+  // These rewards  distributed to all other users still in the pool and entered before the last depositReward method is called.
+  mapping (address => uint256) public rewardToRewardsNotTransferred;
 }

--- a/test/IdleCDOTrancheRewards.js
+++ b/test/IdleCDOTrancheRewards.js
@@ -31,7 +31,7 @@ const erc20Utils = (decimals) => {
   const one = BN("10").pow(BN(decimals));
   const toUnits = v => BN(v).div(one);
   const toUnitsS = v => toUnits(BN(v)).toString();
-  const fromUnits = u => ethers.utils.parseEther(u?.toString());
+  const fromUnits = u => ethers.utils.parseEther(u.toString());
 
   return {
     toUnits,
@@ -268,8 +268,8 @@ describe('IdleCDOTrancheRewards', function() {
 
   it('unstake while the cooling period', async () => {
     const [user1, user2] = this.accounts;
-    await stake(user1, "10")
-    await stake(user2, "10")
+    await stake(user1, "10");
+    await stake(user2, "10");
 
     await depositReward("100");
     const depositBlockNumber = await ethers.provider.getBlockNumber();
@@ -281,18 +281,32 @@ describe('IdleCDOTrancheRewards', function() {
     await checkExpectedUserRewards(user1, "25");
     await checkExpectedUserRewards(user2, "25");
 
-    await unstake(user2, "10")
-
+    await unstake(user2,"10");
+    
     const blocksMined = (await ethers.provider.getBlockNumber()) - depositBlockNumber;
     const user2ExpectedReward = blocksMined * 100 / 2 / this.coolingPeriod;
-
+    
     await checkRewardBalance(user2, user2ExpectedReward);
     await checkExpectedUserRewards(user2, "0");
 
+    await waitBlocks(this.coolingPeriod / 2);
+
     // if a user redeems during the cooling period, the locked rewards not yet available to him, when unlocked, 
     // should be distributed to all other users still in the pool and entered before the last depositReward method is called
+    const user1InitialReward = 100 - user2ExpectedReward;
+    await checkExpectedUserRewards(user1, user1InitialReward);
+    await checkExpectedUserRewards(user2, "0");
+    
+    await depositReward("100");
+    
+    // This time, user1 will receive the full amount because user2 has unstaked.
+    // In total, user1 will be able to claim the previous and current rewards.
     await waitBlocks(this.coolingPeriod / 2);
-    await checkExpectedUserRewards(user1, (100 - user2ExpectedReward));
+    await checkExpectedUserRewards(user1, (user1InitialReward + 50));
+    await checkExpectedUserRewards(user2, "0");
+
+    await waitBlocks(this.coolingPeriod / 2);
+    await checkExpectedUserRewards(user1, (user1InitialReward + 100));
     await checkExpectedUserRewards(user2, "0");
   });
 


### PR DESCRIPTION
This PR fix `IdleCDOTrancheRewards` contract and related tests in order to have working correctly
 
### requirements:
 - any deposit made after a depositReward should give no rewards even if the cooldown is not ended yet
 - if a user redeems during the cooling period, the locked rewards not yet available to him, when unlocked, 
 should be distributed to all other users still in the pool and entered before the last depositReward method is called.

New state variables is introduced
```solidity 
  /// @notice amount of reward that users who `unstake` will not receive. 
  ///         These rewards  distributed to all other users still in the pool 
 ///           and entered before the last depositReward method is called.
  mapping (uint256 => uint256) public indexToRewardNotTransferred;

```
