### PR TITLE
3EUR Pool Deploy

### DIFF
--- a/contracts/interfaces/curve/IMainRegistry.sol
+++ b/contracts/interfaces/curve/IMainRegistry.sol
@@ -4,9 +4,11 @@ pragma solidity 0.8.10;
 interface IMainRegistry {
     function get_pool_from_lp_token(address lp_token)
         external
+        view
         returns (address);
 
     function get_underlying_coins(address pool)
         external
+        view
         returns (address[8] memory);
 }

--- a/contracts/interfaces/curve/IMetaPoolRegistry.sol
+++ b/contracts/interfaces/curve/IMetaPoolRegistry.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+
+interface IMetaPoolRegistry {
+    function get_coins(address) external view returns (address[4] memory);
+    function get_underlying_coins(address) external view returns(address[4] memory);
+}

--- a/contracts/strategies/convex/ConvexFactoryPlainPoolStrategy.sol
+++ b/contracts/strategies/convex/ConvexFactoryPlainPoolStrategy.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+
+import {ConvexBaseStrategy} from "./ConvexBaseStrategy.sol";
+import {IMetaPoolRegistry} from "../../interfaces/curve/IMetaPoolRegistry.sol";
+
+abstract contract ConvexFactoryPlainPoolStrategy is ConvexBaseStrategy {
+    /// @notice curve metapool factory
+    address public constant METAPOOL_FACTORY =
+        address(0xB9fC157394Af804a3578134A6585C0dc9cc990d4);
+
+    /// @dev This method queries the Metapool Factory to get the underlying coins of a
+    ///      plain pool created with the factory (no wrapped assets).
+    function _curveUnderlyingCoins(address _curveLpToken, uint256 _position)
+        internal
+        view
+        override
+        returns (address)
+    {
+        address[4] memory _coins = IMetaPoolRegistry(METAPOOL_FACTORY).get_coins(_curveLpToken);
+        return _coins[_position];
+    }
+}

--- a/contracts/strategies/convex/ConvexStrategy2Token.sol
+++ b/contracts/strategies/convex/ConvexStrategy2Token.sol
@@ -25,7 +25,7 @@ contract ConvexStrategy2Token is ConvexBaseStrategy {
         IERC20Detailed _deposit = IERC20Detailed(curveDeposit);
         uint256 _balance = _deposit.balanceOf(address(this));
         
-        address _pool = _curvePool();
+        address _pool = _curvePool(curveLpToken);
         _deposit.safeApprove(_pool, 0);
         _deposit.safeApprove(_pool, _balance);
 

--- a/contracts/strategies/convex/ConvexStrategy2TokenUnderlying.sol
+++ b/contracts/strategies/convex/ConvexStrategy2TokenUnderlying.sol
@@ -24,7 +24,7 @@ contract ConvexStrategy2TokenUnderlying is ConvexBaseStrategy {
         IERC20Detailed _deposit = IERC20Detailed(curveDeposit);
         uint256 _balance = _deposit.balanceOf(address(this));
         
-        address _pool = _curvePool();
+        address _pool = _curvePool(curveLpToken);
 
         _deposit.safeApprove(_pool, 0);
         _deposit.safeApprove(_pool, _balance);

--- a/contracts/strategies/convex/ConvexStrategy3Token.sol
+++ b/contracts/strategies/convex/ConvexStrategy3Token.sol
@@ -24,7 +24,7 @@ contract ConvexStrategy3Token is ConvexBaseStrategy {
     function _depositInCurve(uint256 _minLpTokens) internal override {
         IERC20Detailed _deposit = IERC20Detailed(curveDeposit);
         uint256 _balance = _deposit.balanceOf(address(this));
-        address _pool = _curvePool();
+        address _pool = _curvePool(curveLpToken);
         
         _deposit.safeApprove(_pool, 0);
         _deposit.safeApprove(_pool, _balance);

--- a/contracts/strategies/convex/ConvexStrategy3TokenUnderlying.sol
+++ b/contracts/strategies/convex/ConvexStrategy3TokenUnderlying.sol
@@ -24,7 +24,7 @@ contract ConvexStrategy3TokenUnderlying is ConvexBaseStrategy {
         IERC20Detailed _deposit = IERC20Detailed(curveDeposit);
         uint256 _balance = _deposit.balanceOf(address(this));
         
-        address _pool = _curvePool();
+        address _pool = _curvePool(curveLpToken);
 
         _deposit.safeApprove(_pool, 0);
         _deposit.safeApprove(_pool, _balance);

--- a/contracts/strategies/convex/ConvexStrategy4Token.sol
+++ b/contracts/strategies/convex/ConvexStrategy4Token.sol
@@ -25,7 +25,7 @@ contract ConvexStrategy4Token is ConvexBaseStrategy {
         IERC20Detailed _deposit = IERC20Detailed(curveDeposit);
         uint256 _balance = _deposit.balanceOf(address(this));
 
-        address _pool = _curvePool();
+        address _pool = _curvePool(curveLpToken);
 
         _deposit.safeApprove(_pool, 0);
         _deposit.safeApprove(_pool, _balance);

--- a/contracts/strategies/convex/ConvexStrategy4TokenUnderlying.sol
+++ b/contracts/strategies/convex/ConvexStrategy4TokenUnderlying.sol
@@ -24,7 +24,7 @@ contract ConvexStrategy4TokenUnderlying is ConvexBaseStrategy {
         IERC20Detailed _deposit = IERC20Detailed(curveDeposit);
         uint256 _balance = _deposit.balanceOf(address(this));
         
-        address _pool = _curvePool();
+        address _pool = _curvePool(curveLpToken);
 
         _deposit.safeApprove(_pool, 0);
         _deposit.safeApprove(_pool, _balance);

--- a/contracts/strategies/convex/ConvexStrategyETH.sol
+++ b/contracts/strategies/convex/ConvexStrategyETH.sol
@@ -29,7 +29,7 @@ contract ConvexStrategyETH is ConvexBaseStrategy {
         // we can accept 0 as minimum, this will be called only by trusted roles
         uint256[2] memory _depositArray;
         _depositArray[depositPosition] = _balance;
-        ICurveDeposit_2token(_curvePool()).add_liquidity{value: _balance}(_depositArray, _minLpTokens);
+        ICurveDeposit_2token(_curvePool(curveLpToken)).add_liquidity{value: _balance}(_depositArray, _minLpTokens);
     }
 
     receive() external payable {}

--- a/contracts/strategies/convex/ConvexStrategyMeta3Pool.sol
+++ b/contracts/strategies/convex/ConvexStrategyMeta3Pool.sol
@@ -26,7 +26,7 @@ contract ConvexStrategyMeta3Pool is ConvexBaseStrategy {
         IERC20Detailed _deposit = IERC20Detailed(curveDeposit);
         uint256 _balance = _deposit.balanceOf(address(this));
 
-        address _pool = _curvePool();
+        address _pool = _curvePool(curveLpToken);
 
         _deposit.safeApprove(CRV_3POOL_DEPOSIT_ZAP, 0);
         _deposit.safeApprove(CRV_3POOL_DEPOSIT_ZAP, _balance);

--- a/contracts/strategies/convex/ConvexStrategyMetaBTC.sol
+++ b/contracts/strategies/convex/ConvexStrategyMetaBTC.sol
@@ -24,7 +24,7 @@ contract ConvexStrategyMetaSBTC is ConvexBaseStrategy {
         IERC20Detailed _deposit = IERC20Detailed(curveDeposit);
         uint256 _balance = _deposit.balanceOf(address(this));
 
-        address _pool = _curvePool();
+        address _pool = _curvePool(curveLpToken);
 
         _deposit.safeApprove(SBTC_DEPOSIT_ZAP, 0);
         _deposit.safeApprove(SBTC_DEPOSIT_ZAP, _balance);

--- a/contracts/strategies/convex/ConvexStrategyPlainPool3Token.sol
+++ b/contracts/strategies/convex/ConvexStrategyPlainPool3Token.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+
+import {ConvexFactoryPlainPoolStrategy} from "./ConvexFactoryPlainPoolStrategy.sol";
+import {ICurveDeposit_3token} from "../../interfaces/curve/ICurveDeposit_3token.sol";
+import {IERC20Detailed} from "../../interfaces/IERC20Detailed.sol";
+
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+contract ConvexStrategyPlainPool3Token is ConvexFactoryPlainPoolStrategy {
+    using SafeERC20Upgradeable for IERC20Detailed;
+
+    /// @notice curve N_COINS for the pool
+    uint256 public constant CURVE_UNDERLYINGS_SIZE = 3;
+
+    /// @return size of the curve deposit array
+    function _curveUnderlyingsSize() internal pure override returns (uint256) {
+        return CURVE_UNDERLYINGS_SIZE;
+    }
+
+    /// @notice Deposits in Curve Metapools for 3 tokens (eg. 3eur)
+    function _depositInCurve(uint256 _minLpTokens) internal override {
+        IERC20Detailed _deposit = IERC20Detailed(curveDeposit);
+        uint256 _balance = _deposit.balanceOf(address(this));
+        address _pool = curveLpToken;
+
+        _deposit.safeApprove(_pool, 0);
+        _deposit.safeApprove(_pool, _balance);
+
+        // we can accept 0 as minimum, this will be called only by trusted roles
+        uint256[3] memory _depositArray;
+        _depositArray[depositPosition] = _balance;
+        ICurveDeposit_3token(_pool).add_liquidity(_depositArray, _minLpTokens);
+    }
+}

--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -12,7 +12,9 @@ const mainnetContracts = {
   idleDAIRisk:  "0xa14eA0E11121e6E951E87c66AFe460A00BCD6A16",
   idleUSDCRisk: "0x3391bc034f2935ef0e1e41619445f998b2680d35",
   idleUSDTRisk: "0x28fAc5334C9f7262b3A3Fe707e250E01053e07b5",
+  agEUR: '0x1a7e4e63778b4f12a199c062f3efdd288afcbce8',
   DAI: '0x6b175474e89094c44da98b954eedeac495271d0f',
+  FEI: '0x956F47F50A910163D8BF957Cf5846D573E7f87CA',
   cDAI: '0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643',
   USDC: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   cUSDC: '0x39aa39c021dfbae8fac545936693ac917d5e7563',
@@ -27,6 +29,8 @@ const mainnetContracts = {
   CRV_LUSD3CRV: '0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA',
   CRV_MIM3CRV: '0x5a6A4D54456819380173272A5E8E9B9904BdF41B',
   CRV_FRAX3CRV: '0xd632f22692FaC7611d2AA1C0D552930D43CAEd3B',
+  CRV_3EUR: '0xb9446c4Ef5EBE66268dA6700D26f96273DE3d571',
+  uniRouter: '0x7a250d5630b4cf539739df2c5dacb4c659f2488d',
   sushiRouter: '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F',
   stkAAVE: '0x4da27a545c0c5b758a6ba100e3a049001de870f5',
   COMP: '0xc00e94Cb662C3520282E6f5717214004A7f26888',
@@ -318,6 +322,20 @@ exports.deployTokens = {
     ],
     cdo: CDOs.cvxfrax3crv,
     ...baseCDOArgs
+  },
+  cvx3eurCrv: {
+    decimals: 18,
+    underlying: mainnetContracts.CRV_3EUR,
+    strategyName: 'ConvexStrategyPlainPool3Token',
+    strategyParams: [
+      60, // convexPoolId
+      'owner', // owner address
+      1500, // 6 hours harvested rewards release
+      [mainnetContracts.agEUR, addr0, 0], // curveArgs (deposit, depositor, position)
+      [[mainnetContracts.CVX, mainnetContracts.sushiRouter, [mainnetContracts.CVX, mainnetContracts.WETH]],
+      [mainnetContracts.CRV, mainnetContracts.sushiRouter, [mainnetContracts.CRV, mainnetContracts.WETH]]], // rewards (token, router, path)
+      [mainnetContracts.uniRouter, [mainnetContracts.WETH, mainnetContracts.FEI, mainnetContracts.agEUR]] // weth 2 deposit
+    ]
   }
 };
 

--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -335,7 +335,9 @@ exports.deployTokens = {
       [[mainnetContracts.CVX, mainnetContracts.sushiRouter, [mainnetContracts.CVX, mainnetContracts.WETH]],
       [mainnetContracts.CRV, mainnetContracts.sushiRouter, [mainnetContracts.CRV, mainnetContracts.WETH]]], // rewards (token, router, path)
       [mainnetContracts.uniRouter, [mainnetContracts.WETH, mainnetContracts.FEI, mainnetContracts.agEUR]] // weth 2 deposit
-    ]
+    ],
+    cdo: CDOs.cvx3eurCrv,
+    ...baseCDOArgs
   }
 };
 

--- a/test/integration/convex/ConvexStrategyPlainPool3Token.js
+++ b/test/integration/convex/ConvexStrategyPlainPool3Token.js
@@ -1,0 +1,141 @@
+require("hardhat/config")
+const { BigNumber } = require("@ethersproject/bignumber");
+const helpers = require("../../../scripts/helpers");
+const { expect } = require("chai");
+const addresses = require("../../../lib/addresses");
+const { smock } = require('@defi-wonderland/smock');
+const { ethers, network } = require("hardhat");
+
+require('chai').use(smock.matchers);
+
+const BN = n => BigNumber.from(n.toString());
+const ONE_TOKEN = (n, decimals) => BigNumber.from('10').pow(BigNumber.from(n));
+const MAX_UINT = BN('115792089237316195423570985008687907853269984665640564039457584007913129639935');
+const POOL_ID_CRV3EUR = 60;
+const DEPOSIT_POSITION_CRV3EUR = 0;
+const WHALE_CRV3EUR = '0x02ef8147e2d0997cca48d99f01bad846d16558fa';
+const FEI = '0x956f47f50a910163d8bf957cf5846d573e7f87ca';
+const agEUR = '0x1a7e4e63778b4f12a199c062f3efdd288afcbce8';
+const TOKEN_CRV3EUR = '0xb9446c4Ef5EBE66268dA6700D26f96273DE3d571';
+const CVX = '0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B';
+const CRV = '0xD533a949740bb3306d119CC777fa900bA034cd52';
+const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const UNI_ROUTER = '0x7a250d5630b4cf539739df2c5dacb4c659f2488d';
+const SUSHI_ROUTER = '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F';
+
+const CVXWETH = [CVX, WETH]
+const CRVWETH = [CRV, WETH]
+const WETHAGEUR = [WETH, FEI, agEUR]
+
+
+describe("ConvexStrategyMeta3Token (using 3eur for tests)", async () => {
+  
+  before(async () => {
+    // setup
+    signers = await ethers.getSigners();
+    owner = signers[0];
+    Random = signers[1];
+    RandomAddr = Random.address;
+    Random2Addr = signers[2].address;
+
+    one = ONE_TOKEN(18);
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    erc20_CRV3EUR = MockERC20.attach(TOKEN_CRV3EUR);
+
+    booster = await ethers.getContractAt("IBooster", "0xF403C135812408BFbE8713b5A23a04b3D48AAE31");
+
+    // funding the buyer
+    await owner.sendTransaction({to: RandomAddr, value: ethers.utils.parseEther("20")});
+    // funding the whale to transfer CRV3EUR
+    await owner.sendTransaction({to: WHALE_CRV3EUR, value: ethers.utils.parseEther("20")});
+
+    curve_args = [agEUR, addresses.addr0, DEPOSIT_POSITION_CRV3EUR]
+    reward_cvx = [CVX, SUSHI_ROUTER, CVXWETH];
+    reward_crv = [CRV, SUSHI_ROUTER, CRVWETH];
+    weth2deposit = [UNI_ROUTER, WETHAGEUR];
+  });
+  
+  beforeEach(async () => {
+    strategy = await helpers.deployUpgradableContract('ConvexStrategyPlainPool3Token', [POOL_ID_CRV3EUR, owner.address, 0, curve_args, [reward_crv, reward_cvx], weth2deposit]);
+  });
+
+  afterEach(async () => {
+    const balanceCRV3EUR = await erc20_CRV3EUR.balanceOf(RandomAddr);
+    await helpers.fundWallets(TOKEN_CRV3EUR, [WHALE_CRV3EUR], RandomAddr, balanceCRV3EUR);
+  });
+
+  it("should redeemRewards (simulate 7 days)", async () => {
+    const addr = RandomAddr;
+    const _amount = BN('30000').mul(one);
+
+    await helpers.fundWallets(TOKEN_CRV3EUR, [RandomAddr], WHALE_CRV3EUR, _amount);
+
+    setWhitelistedCDO(addr);
+
+    await deposit(addr, _amount);
+
+    // happy path: the strategy earns money! yay!
+    
+    // TODO: is there any way to calculate rewards and expected return in a PRECISE way?
+    // harvest finance and co. seems to not cover the precision of the strategy, testing instead
+    // that at least it earns something...
+
+    // forwarding the chain to retrieve some rewards (1 day)
+    // simulating the whole process 
+
+    // Using half days is to simulate how we doHardwork in the real world
+    let days = 15;
+    let oneDay = 3600 * 24;
+    const initialSharePrice = await strategy.price();
+    for(let i = 0; i < days; i++) {
+      // distribute CRVs to reward pools, this is not an automatic
+      booster.earmarkRewards(POOL_ID_CRV3EUR);
+
+      await network.provider.send("evm_increaseTime", [oneDay]);
+      await network.provider.send("evm_mine", []);
+
+      const roundInitialPrice = await strategy.price();
+      await redeemRewards(addr);
+      const roundFinalPrice = await strategy.price();
+
+      // basic expectation
+      expect(roundFinalPrice.gt(roundInitialPrice)).to.be.true;
+    }
+    const finalSharePrice = await strategy.price();
+
+    // basic expectation
+    expect(finalSharePrice.gt(initialSharePrice)).to.be.true;
+
+    const priceGain = ethers.utils.formatEther(finalSharePrice.sub(initialSharePrice));
+    
+    console.log('💵 Price gain (15 days): ', priceGain);
+
+    // No token left in the contract
+    expect(await erc20_CRV3EUR.balanceOf(strategy.address)).to.equal(0);
+    expect(await strategy.balanceOf(strategy.address)).to.equal(0);
+  });
+  
+
+
+  const setWhitelistedCDO = async (addr) => {
+    await helpers.sudoCall(owner.address, strategy, 'setWhitelistedCDO', [addr]);
+  }
+
+  const deposit = async (addr, amount) => {
+    await helpers.sudoCall(addr, erc20_CRV3EUR, 'approve', [strategy.address, MAX_UINT]);
+    await helpers.sudoCall(addr, strategy, 'deposit', [amount]);
+  }
+  
+  const redeemRewards = async (addr) => {
+    // encode params for redeemRewards: uint256[], uint256, uint256
+    const params = [
+      [5, 5],
+      3,
+      4
+    ];
+    const extraData = helpers.encodeParams(['uint256[]', 'uint256', 'uint256'], params);
+    const [a, b, res] = await helpers.sudoCall(addr, strategy, 'redeemRewards', [extraData]);
+    return res;
+  }
+});


### PR DESCRIPTION
This PR introduces:

- `ConvexFactoryPlainPoolStrategy` interface, useful for when pools' underlyings can only be queried from the metapool factory contract. 3EUR Curve pool was one of this.
- Not reading the Curve LP Token from storage when checking if the deposit token in the right one (prevents an SLOAD). This is achieved by passing the Curve LP Token as an argument to `_curveUnderlyingCoins`.
- Tests and deploy scripts for 3EUR Pool