### PR TITLE
Convex mUSD strategy

### DIFF
--- a/contracts/strategies/convex/ConvexStrategyMUSD.sol
+++ b/contracts/strategies/convex/ConvexStrategyMUSD.sol
@@ -29,8 +29,6 @@ contract ConvexStrategyMUSD is ConvexBaseStrategy {
         _deposit.safeApprove(CURVE_MUSD_DEPOSIT, 0);
         _deposit.safeApprove(CURVE_MUSD_DEPOSIT, _balance);
 
-        // we can accept 0 as minimum, this will be called only by trusted roles
-        // we also use the zap to deploy funds into a meta pool
         uint256[4] memory _depositArray;
         _depositArray[depositPosition] = _balance;
         IDepositZap(CURVE_MUSD_DEPOSIT).add_liquidity(_depositArray, _minLpTokens);

--- a/contracts/strategies/convex/ConvexStrategyMUSD.sol
+++ b/contracts/strategies/convex/ConvexStrategyMUSD.sol
@@ -1,0 +1,38 @@
+
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+
+import {ConvexBaseStrategy} from "./ConvexBaseStrategy.sol";
+import {IDepositZap} from "../../interfaces/curve/IDepositZap.sol";
+import {IERC20Detailed} from "../../interfaces/IERC20Detailed.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+contract ConvexStrategyMUSD is ConvexBaseStrategy {
+    using SafeERC20Upgradeable for IERC20Detailed;
+
+    /// @notice curve N_COINS for the pool
+    uint256 public constant CURVE_UNDERLYINGS_SIZE = 4;
+    /// @notice curve 3pool deposit zap
+    address public constant CURVE_MUSD_DEPOSIT =
+        address(0x803A2B40c5a9BB2B86DD630B274Fa2A9202874C2);
+
+    /// @return size of the curve deposit array
+    function _curveUnderlyingsSize() internal pure override returns (uint256) {
+        return CURVE_UNDERLYINGS_SIZE;
+    }
+
+    /// @notice Deposits in Curve for metapools based on 3pool
+    function _depositInCurve(uint256 _minLpTokens) internal override {
+        IERC20Detailed _deposit = IERC20Detailed(curveDeposit);
+        uint256 _balance = _deposit.balanceOf(address(this));
+
+        _deposit.safeApprove(CURVE_MUSD_DEPOSIT, 0);
+        _deposit.safeApprove(CURVE_MUSD_DEPOSIT, _balance);
+
+        // we can accept 0 as minimum, this will be called only by trusted roles
+        // we also use the zap to deploy funds into a meta pool
+        uint256[4] memory _depositArray;
+        _depositArray[depositPosition] = _balance;
+        IDepositZap(CURVE_MUSD_DEPOSIT).add_liquidity(_depositArray, _minLpTokens);
+    }
+}


### PR DESCRIPTION
## Reason for this PR

Some custom logic is needed to deploy mUSD strategy. Old metapools have custom zappers: https://curve.readthedocs.io/ref-addresses.html?#metapools

## Changes

Added a new strategy derived from `ConvexBaseStrategy` calling the right zapper to add liquidity in musd pool.