### PR TITLE
Auto loss mgmt for IdleCDO

### DIFF
--- a/contracts/IdleCDO.sol
+++ b/contracts/IdleCDO.sol
@@ -951,6 +951,10 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
   /// @dev can be called by both the owner and the guardian
   function emergencyShutdown() external {
     _checkOnlyOwnerOrGuardian();
+    _emergencyShutdown();
+  }
+
+  function _emergencyShutdown() internal {
     // prevent deposits
     _pause();
     // prevent withdraws

--- a/contracts/IdleCDOAutoLossVariant.sol
+++ b/contracts/IdleCDOAutoLossVariant.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+
+import '@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol';
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+import "./IdleCDO.sol";
+import "./strategies/euler/IdleLeveragedEulerStrategy.sol";
+
+/// @title IdleCDO variant for automatically spread any losses, up to a threshold, 
+/// directly to junior holders. Based on IdleCDOLeveregedEulerVarial.sol
+/// @author Idle DAO, @bugduino
+/// @dev In this variant the `_checkDefault` calculates if strategy price decreased 
+/// more than X% with X configurable. `_virtualPriceAuxVariant` is also modified to redistribute
+/// loss to junior holders only
+contract IdleCDOAutoLossVariant is IdleCDO {
+  using SafeERC20Upgradeable for IERC20Detailed;
+  // This variable will get appended at the end of the IdleCDOStorage
+  // be careful when upgrading
+  uint256 public maxDecreaseDefault;
+
+  function _additionalInit() internal override {
+    maxDecreaseDefault = 5000; // 5%
+  }
+
+  /// @dev check if any loan for the pool is defaulted
+  function _checkDefault() override internal view {
+    uint256 _lastPrice = lastStrategyPrice;
+
+    // calculate max % decrease
+    if (!skipDefaultCheck) {
+      require(_lastPrice - (_lastPrice * maxDecreaseDefault / FULL_ALLOC) <= _strategyPrice(), "4");
+    }
+  }
+
+  /// @notice set the max value, in % where `100000` = 100%, of accettable price decrease for the strategy
+  /// @dev automatically reverts if strategyPrice decreased more than `_maxDecreaseDefault`
+  /// @param _maxDecreaseDefault in tranche tokens
+  function setMaxDecreaseDefault(uint256 _maxDecreaseDefault) external {
+    _checkOnlyOwner();
+    require(_maxDecreaseDefault < FULL_ALLOC);
+    maxDecreaseDefault = _maxDecreaseDefault;
+  }
+
+  /// @notice calculates the current tranches price considering the interest/loss that is yet to be splitted
+  /// ie the interest/loss generated since the last update of priceAA and priceBB (done on depositXX/withdrawXX/harvest)
+  /// useful for showing updated gains on frontends
+  /// @param _tranche address of the requested tranche
+  /// @return _virtualPrice tranche price considering all interest/losses
+  function virtualPrice(address _tranche) public override view returns (uint256 _virtualPrice) {
+    // get both NAVs, because we need the total NAV anyway
+    uint256 _lastNAVAA = lastNAVAA;
+    uint256 _lastNAVBB = lastNAVBB;
+
+    (_virtualPrice, ) = _virtualPriceAuxVariant(
+      _tranche,
+      getContractValue(), // nav
+      _lastNAVAA + _lastNAVBB, // lastNAV
+      _tranche == AATranche ? _lastNAVAA : _lastNAVBB, // lastTrancheNAV
+      trancheAPRSplitRatio
+    );
+  }
+
+  /// @notice calculates the current tranches price considering the interest/loss that is yet to be splitted and the
+  /// total gain/loss for a specific tranche
+  /// @param _tranche address of the requested tranche
+  /// @param _nav current NAV
+  /// @param _lastNAV last saved NAV
+  /// @param _lastTrancheNAV last saved tranche NAV
+  /// @param _trancheAPRSplitRatio APR split ratio for AA tranche
+  /// @return _virtualPrice tranche price considering all interest
+  /// @return _totalTrancheGain (int256) tranche gain/loss since last update
+  function _virtualPriceAuxVariant(
+    address _tranche,
+    uint256 _nav,
+    uint256 _lastNAV,
+    uint256 _lastTrancheNAV,
+    uint256 _trancheAPRSplitRatio
+  ) internal view returns (uint256 _virtualPrice, int256 _totalTrancheGain) {
+    // Check if there are tranche holders
+    uint256 trancheSupply = IdleCDOTranche(_tranche).totalSupply();
+    if (_lastNAV == 0 || trancheSupply == 0) {
+      return (oneToken, 0);
+    }
+    // In order to correctly split the interest or loss generated between AA and BB tranche holders
+    // (according to the trancheAPRSplitRatio) we need to know how much interest/loss we gained
+    // since the last price update (during a depositXX/withdrawXX/harvest)
+    // To do that we need to get the current value of the assets in this contract
+    // and the last saved one (always during a depositXX/withdrawXX/harvest)
+    // Calculate the total gain/loss
+    int256 totalGain = int256(_nav) - int256(_lastNAV);
+    if (totalGain == 0) {
+      return (virtualPrice(_tranche), 0);
+    }
+
+    // Remove performance fee for gains
+    if (totalGain > 0) {
+      totalGain -= totalGain * int256(fee) / int256(FULL_ALLOC);
+    }
+
+    address _AATranche = AATranche;
+    bool _isAATranche = _tranche == _AATranche;
+    // Get the supply of the other tranche and
+    // if it's 0 then give all gain to the current `_tranche` holders
+    if (IdleCDOTranche(_isAATranche ? BBTranche : _AATranche).totalSupply() == 0) {
+      _totalTrancheGain = totalGain;
+    } else {
+      if (totalGain > 0) {
+        // Split the net gain, with precision loss favoring the AA tranche.
+        int256 totalBBGain = totalGain * int256(FULL_ALLOC - _trancheAPRSplitRatio) / int256(FULL_ALLOC);
+        // The new NAV for the tranche is old NAV + total gain for the tranche
+        _totalTrancheGain = _isAATranche ? (totalGain - totalBBGain) : totalBBGain;
+      } else {
+        // Redirect the whole loss (which is < maxDecreaseDefault) to junior holders
+        _totalTrancheGain = _isAATranche ? int256(0) : totalGain;
+      }
+    }
+    // Split the new NAV (_lastTrancheNAV + _totalTrancheGain) per tranche token
+    _virtualPrice = uint256(int256(_lastTrancheNAV) + int256(_totalTrancheGain)) * ONE_TRANCHE_TOKEN / trancheSupply;
+  }
+
+  /// @notice this method is called on depositXX/withdrawXX/harvest and
+  /// updates the accounting of the contract and effectively splits the yield/loss between the
+  /// AA and BB tranches
+  /// @dev this method:
+  /// - update tranche prices (priceAA and priceBB)
+  /// - update net asset value for both tranches (lastNAVAA and lastNAVBB)
+  /// - update fee accounting (unclaimedFees)
+  function _updateAccounting() internal override {
+    uint256 _lastNAVAA = lastNAVAA;
+    uint256 _lastNAVBB = lastNAVBB;
+    uint256 _lastNAV = _lastNAVAA + _lastNAVBB;
+    uint256 nav = getContractValue();
+    uint256 _aprSplitRatio = trancheAPRSplitRatio;
+
+    // If gain is > 0, then collect some fees in `unclaimedFees`
+    if (nav > _lastNAV) {
+      unclaimedFees += (nav - _lastNAV) * fee / FULL_ALLOC;
+    }
+    (uint256 _priceAA, int256 _totalAAGain) = _virtualPriceAuxVariant(AATranche, nav, _lastNAV, _lastNAVAA, _aprSplitRatio);
+    (uint256 _priceBB, int256 _totalBBGain) = _virtualPriceAuxVariant(BBTranche, nav, _lastNAV, _lastNAVBB, _aprSplitRatio);
+
+    lastNAVAA = uint256(int256(_lastNAVAA) + _totalAAGain);
+    lastNAVBB = uint256(int256(_lastNAVBB) + _totalBBGain);
+    priceAA = _priceAA;
+    priceBB = _priceBB;
+  }
+}

--- a/contracts/IdleCDOAutoLossVariant.sol
+++ b/contracts/IdleCDOAutoLossVariant.sol
@@ -24,13 +24,11 @@ contract IdleCDOAutoLossVariant is IdleCDO {
     maxDecreaseDefault = 5000; // 5%
   }
 
-  /// @dev check if any loan for the pool is defaulted
+  /// @dev check if strategy price decreased more than `maxDecreaseDefault` %
   function _checkDefault() override internal view {
-    uint256 _lastPrice = lastStrategyPrice;
-
-    // calculate max % decrease
     if (!skipDefaultCheck) {
-      require(_lastPrice - (_lastPrice * maxDecreaseDefault / FULL_ALLOC) <= _strategyPrice(), "4");
+      // calculate if % of decrease of strategyPrice is within maxDecreaseDefault
+      require(lastStrategyPrice * (FULL_ALLOC - maxDecreaseDefault) / FULL_ALLOC <= _strategyPrice(), "4");
     }
   }
 
@@ -83,15 +81,17 @@ contract IdleCDOAutoLossVariant is IdleCDO {
     if (_lastNAV == 0 || trancheSupply == 0) {
       return (oneToken, 0);
     }
-    // In order to correctly split the interest or loss generated between AA and BB tranche holders
+
+    // In order to correctly split the interest generated between AA and BB tranche holders
     // (according to the trancheAPRSplitRatio) we need to know how much interest/loss we gained
     // since the last price update (during a depositXX/withdrawXX/harvest)
     // To do that we need to get the current value of the assets in this contract
     // and the last saved one (always during a depositXX/withdrawXX/harvest)
     // Calculate the total gain/loss
     int256 totalGain = int256(_nav) - int256(_lastNAV);
+    // If there is no gain/loss return the current price
     if (totalGain == 0) {
-      return (virtualPrice(_tranche), 0);
+      return (_tranchePrice(_tranche), 0);
     }
 
     // Remove performance fee for gains
@@ -100,10 +100,11 @@ contract IdleCDOAutoLossVariant is IdleCDO {
     }
 
     address _AATranche = AATranche;
+    address _BBTranche = BBTranche;
     bool _isAATranche = _tranche == _AATranche;
     // Get the supply of the other tranche and
     // if it's 0 then give all gain to the current `_tranche` holders
-    if (IdleCDOTranche(_isAATranche ? BBTranche : _AATranche).totalSupply() == 0) {
+    if (IdleCDOTranche(_isAATranche ? _BBTranche : _AATranche).totalSupply() == 0) {
       _totalTrancheGain = totalGain;
     } else {
       if (totalGain > 0) {
@@ -111,13 +112,39 @@ contract IdleCDOAutoLossVariant is IdleCDO {
         int256 totalBBGain = totalGain * int256(FULL_ALLOC - _trancheAPRSplitRatio) / int256(FULL_ALLOC);
         // The new NAV for the tranche is old NAV + total gain for the tranche
         _totalTrancheGain = _isAATranche ? (totalGain - totalBBGain) : totalBBGain;
-      } else {
-        // Redirect the whole loss (which is < maxDecreaseDefault) to junior holders
-        _totalTrancheGain = _isAATranche ? int256(0) : totalGain;
+      } else { // totalGain is negative here
+        // Redirect the whole loss (which should be < maxDecreaseDefault) to junior holders
+        int256 _juniorTVL = int256(_isAATranche ? _lastNAV - _lastTrancheNAV : _lastTrancheNAV);
+        int256 _newJuniorTVL = _juniorTVL + totalGain; 
+        // if junior holders have enough TVL to cover
+        if (_newJuniorTVL > 0) {
+          _totalTrancheGain = _isAATranche ? int256(0) : totalGain;
+        } else {
+          // otherwise all loss minus junior tvl to senior
+          if (!_isAATranche) {
+            // juniors have no more claim (we set price to *1 wei* to avoid 0), gain is set to -juniorTVL
+            return (1, -_juniorTVL);
+          }
+          // seniors get the loss - oldjuniorTVL (- *1 wei* for each tranche junior tranche token)
+          _totalTrancheGain = _newJuniorTVL - int256(IdleCDOTranche(_BBTranche).totalSupply() / ONE_TRANCHE_TOKEN);
+        }
       }
     }
     // Split the new NAV (_lastTrancheNAV + _totalTrancheGain) per tranche token
     _virtualPrice = uint256(int256(_lastTrancheNAV) + int256(_totalTrancheGain)) * ONE_TRANCHE_TOKEN / trancheSupply;
+  }
+
+  /// @notice this method updates the accounting of the contract and effectively splits the yield/loss between the
+  /// AA and BB tranches. This can be called at any time as is called automatically on each deposit/redeem. It's here
+  /// just to be called when a default happened, as deposits/redeems are paused, but we need to update
+  /// the loss for junior holders
+  function updateAccounting() external {
+    _checkOnlyOwnerOrGuardian();
+    skipDefaultCheck = true;
+    _updateAccounting();
+    // update accounting can set `skipDefaultCheck` to true in case of default
+    // but this can be manually be reset to true if needed
+    skipDefaultCheck = false;
   }
 
   /// @notice this method is called on depositXX/withdrawXX/harvest and
@@ -133,16 +160,30 @@ contract IdleCDOAutoLossVariant is IdleCDO {
     uint256 _lastNAV = _lastNAVAA + _lastNAVBB;
     uint256 nav = getContractValue();
     uint256 _aprSplitRatio = trancheAPRSplitRatio;
-
     // If gain is > 0, then collect some fees in `unclaimedFees`
     if (nav > _lastNAV) {
       unclaimedFees += (nav - _lastNAV) * fee / FULL_ALLOC;
     }
     (uint256 _priceAA, int256 _totalAAGain) = _virtualPriceAuxVariant(AATranche, nav, _lastNAV, _lastNAVAA, _aprSplitRatio);
     (uint256 _priceBB, int256 _totalBBGain) = _virtualPriceAuxVariant(BBTranche, nav, _lastNAV, _lastNAVBB, _aprSplitRatio);
-
     lastNAVAA = uint256(int256(_lastNAVAA) + _totalAAGain);
-    lastNAVBB = uint256(int256(_lastNAVBB) + _totalBBGain);
+
+    // if we have a loss for juniors and the loss is gte lastNAV we trigger a default
+    if (_totalBBGain < 0 && -_totalBBGain >= int256(_lastNAVBB)) {
+      if (skipDefaultCheck) {
+        // This path will be called when a default happens and guardian calls
+        // `updateAccounting` after setting skipDefaultCheck
+        // We set lastNAVBB to 1 wei * tranche token
+        lastNAVBB = IdleCDOTranche(BBTranche).totalSupply() / ONE_TRANCHE_TOKEN;
+        _emergencyShutdown();
+      } else {
+        // revert with 'default' error (4) as seniors will have a loss not covered. 
+        // `updateAccounting` should be manually called to distribute loss
+        require(false, "4"); 
+      }
+    } else {
+      lastNAVBB = uint256(int256(_lastNAVBB) + _totalBBGain);
+    }
     priceAA = _priceAA;
     priceBB = _priceBB;
   }

--- a/contracts/interfaces/ICToken.sol
+++ b/contracts/interfaces/ICToken.sol
@@ -3,4 +3,5 @@ pragma solidity 0.8.10;
 
 interface ICToken {
   function accrueInterest() external;
+  function exchangeRateStored() external view returns (uint256);
 }

--- a/test/foundry/IdleCDOAutoLossVariant.t.sol
+++ b/test/foundry/IdleCDOAutoLossVariant.t.sol
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.10;
+import "../../contracts/interfaces/ICToken.sol";
+import "../../contracts/strategies/idle/IdleStrategy.sol";
+import "../../contracts/IdleCDOAutoLossVariant.sol";
+import "./TestIdleCDOBase.sol";
+
+// NOTE: IMPORTANT tests are made at block 16368877 where idleUSDC had all deposited in compound
+// this is crucial for the test as to mock a default we decrease `exchangeRateStored` of the corresponding
+// cToken associated with the idleToken. If another block is used make sure to mock the correct call.
+// It's not enough to mock strategy.price() otherwise on redeems the wrong number of strategyTokens will be burned
+
+contract TestIdleCDOAutoLossVariant is TestIdleCDOBase {
+  using stdStorage for StdStorage;
+  using SafeERC20Upgradeable for IERC20Detailed;
+
+  // Idle-USDC Best-Yield v4
+  address internal constant UNDERLYING = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+  address internal constant idleToken = 0x5274891bEC421B39D23760c04A6755eCB444797C;
+  // NOTE check *NOTE* at beginning of the contract
+  address internal constant cToken = 0x39AA39c021dfbaE8faC545936693aC917d5E7563;
+
+  function _selectFork() public override {
+    // IdleUSDC deposited all in compund
+    vm.selectFork(vm.createFork(vm.envString("ETH_RPC_URL"), 16368877));
+  }
+
+  function _deployLocalContracts() internal override returns (IdleCDO _cdo) {
+    address _owner = address(0xdeadbad);
+    address _rebalancer = address(0xbaddead);
+    (address _strategy, address _underlying) = _deployStrategy(_owner);
+
+    // deploy idleCDO and tranches
+    _cdo = _deployCDO();
+    stdstore.target(address(_cdo)).sig(_cdo.token.selector).checked_write(address(0));
+    address[] memory incentiveTokens = new address[](0);
+    _cdo.initialize(
+      0,
+      _underlying,
+      address(this), // governanceFund,
+      _owner, // owner,
+      _rebalancer, // rebalancer,
+      _strategy, // strategy
+      20000, // apr split
+      0, // deprecated
+      incentiveTokens
+    );
+
+    vm.startPrank(_owner);
+    _cdo.setUnlentPerc(0);
+    _cdo.setFee(0);
+    _cdo.setIsAYSActive(true);
+    vm.stopPrank();
+
+    _postDeploy(address(_cdo), _owner);
+  }
+
+  function _deployStrategy(address _owner) internal override returns (address _strategy, address _underlying) {
+    _underlying = UNDERLYING;
+    underlying = IERC20Detailed(_underlying);
+    strategy = new IdleStrategy();
+    _strategy = address(strategy);
+    stdstore.target(_strategy).sig(strategy.token.selector).checked_write(address(0));
+    IdleStrategy(_strategy).initialize(idleToken, _owner);
+  }
+
+  function _deployCDO() internal override returns (IdleCDO _cdo) {
+    _cdo = new IdleCDOAutoLossVariant();
+  }
+
+  function _postDeploy(address _cdo, address _owner) internal override {
+    vm.prank(_owner);
+    IdleStrategy(address(strategy)).setWhitelistedCDO(address(_cdo));
+  }
+
+  function _pokeLendingProtocol() internal override {
+    ICToken(cToken).accrueInterest();
+  }
+
+  // ###################################
+  // ############ TESTS ################
+  // ###################################
+
+  function testInitialize() public override {
+    super.testInitialize();
+    assertEq(IdleCDOAutoLossVariant(address(idleCDO)).maxDecreaseDefault(), 5000);
+  }
+
+  function testOnlyIdleCDO() public override runOnForkingNetwork(MAINNET_CHIANID) {}
+
+  function testCantReinitialize() external override runOnForkingNetwork(MAINNET_CHIANID) {
+      vm.expectRevert(bytes("Initializable: contract is already initialized"));
+      IdleStrategy(address(strategy)).initialize(idleToken, owner);
+  }
+
+  function testDepositWithLossCovered() external runOnForkingNetwork(MAINNET_CHIANID) {
+    uint256 amount = 10000 * ONE_SCALE;
+    // fee is set to 10% and release block period to 0
+    (uint256 preAAPrice, uint256 preBBPrice) = _doDepositsWithInterest(amount, amount);
+
+    uint256 currPrice = strategy.price();
+    uint256 maxDecrease = IdleCDOAutoLossVariant(address(idleCDO)).maxDecreaseDefault();
+    uint256 unclaimedFees = idleCDO.unclaimedFees();
+    // now let's simulate a loss by decreasing strategy price
+    // curr price - 5%
+    vm.mockCall(
+      address(strategy),
+      abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
+      abi.encode(currPrice * (FULL_ALLOC - maxDecrease) / FULL_ALLOC)
+    );
+
+    uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
+    uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
+    // juniors lost about 10% as there were seniors to cover
+    assertApproxEqAbs(
+      preBBPrice * 90000/100000,
+      postBBPrice, 
+      200 // 200 wei to account for interest accrued
+    );
+    // seniors are covered
+    assertEq(preAAPrice, postAAPrice, 'AA price unaffected');
+    assertEq(idleCDO.priceAA(), preAAPrice, 'AA price not updated until new interaction');
+    assertEq(idleCDO.priceBB(), preBBPrice, 'BB price not updated until new interaction');
+
+    _depositWithUser(idleCDO.rebalancer(), amount, true);
+    _depositWithUser(idleCDO.rebalancer(), amount, false);
+
+    uint256 postDepositAAPrice = idleCDO.virtualPrice(address(AAtranche));
+    uint256 postDepositBBPrice = idleCDO.virtualPrice(address(BBtranche));
+
+    assertEq(postDepositAAPrice, postAAPrice, 'AA price did not change after deposit');
+    assertEq(postDepositBBPrice, postBBPrice, 'BB price did not change after deposit');
+    assertEq(idleCDO.priceAA(), postDepositAAPrice, 'AA saved price updated');
+    assertEq(idleCDO.priceBB(), postDepositBBPrice, 'BB saved price updated');
+
+    assertEq(idleCDO.unclaimedFees(), unclaimedFees, 'Fees did not increase');
+    vm.clearMockedCalls();
+  }
+
+  function testRedeemWithLossCovered() external runOnForkingNetwork(MAINNET_CHIANID) {
+    uint256 maxDecrease = IdleCDOAutoLossVariant(address(idleCDO)).maxDecreaseDefault();
+    uint256 amount = 10000 * ONE_SCALE;
+    // fee is set to 10% and release block period to 0, AARatio 66%
+    (uint256 preAAPrice, uint256 preBBPrice) = _doDepositsWithInterest(amount * 2, amount);
+
+    // now let's simulate a loss by decreasing cToken price (so to decrease strategy.price), curr price - 5%
+    vm.mockCall(
+      address(cToken),
+      abi.encodeWithSelector(ICToken.exchangeRateStored.selector),
+      abi.encode(ICToken(cToken).exchangeRateStored() * (FULL_ALLOC - maxDecrease) / FULL_ALLOC)
+    );
+
+    uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
+    uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
+    // juniors lost about 15% as there were 2x seniors to cover
+    assertApproxEqAbs(
+      postBBPrice, 
+      preBBPrice * 85000/100000,
+      1000, // 1000 wei to account for interest accrued
+      'BB price decreased'
+    );
+    // seniors are covered
+    assertEq(preAAPrice, postAAPrice, 'AA price unaffected');
+    uint256 balPre = underlying.balanceOf(address(this));
+    // we redeem half of the balance to avoid having only feeReceiver as AA holders
+    // otherwise any leftover will easily push AA price up
+    idleCDO.withdrawAA(AAtranche.balanceOf(address(this)) / 2);
+    uint256 balPost = underlying.balanceOf(address(this));
+    assertGt(balPost - balPre, amount, 'AA gained something as loss was totally covered');
+
+    // senior v price should be equal to the one before or at most 1 wei greater due to rounding
+    assertApproxEqAbs(
+      idleCDO.virtualPrice(address(AAtranche)), postAAPrice, 1, 
+      'AA price after withdraw did not change or increased'
+    );
+    assertGe(idleCDO.virtualPrice(address(AAtranche)), postAAPrice, 'AA price after withdraw did not change or increased');
+    // junior v price should be unchanged
+    assertEq(idleCDO.virtualPrice(address(BBtranche)), postBBPrice, 'BB price after withdraw did not change');
+
+    // junior lost about 15%
+    idleCDO.withdrawBB(BBtranche.balanceOf(address(this)));
+    uint256 balPostPost = underlying.balanceOf(address(this));
+    assertApproxEqRel(
+      balPostPost - balPost, 
+      amount * 85000/100000, // lost 15% - interest accrued (about 0.2%)
+      3e15, // 0.3% tolerance
+      'BB lost 10% (minus interest accrued)'
+    );
+
+    vm.clearMockedCalls();
+  }
+
+  function testDepositRedeemWithLossShutdown() external runOnForkingNetwork(MAINNET_CHIANID) {
+    uint256 amount = 10000 * ONE_SCALE;
+    // fee is set to 10% and release block period to 0
+
+    // AA Ratio 98%
+    (uint256 preAAPrice, uint256 preBBPrice) = _doDepositsWithInterest(amount - amount / 50, amount / 50);
+
+    uint256 currPrice = strategy.price();
+    uint256 maxDecrease = IdleCDOAutoLossVariant(address(idleCDO)).maxDecreaseDefault();
+    uint256 unclaimedFees = idleCDO.unclaimedFees();
+    // now let's simulate a loss by decreasing strategy price
+    // curr price - 5%, this will trigger a default because the loss is >= junior tvl
+    vm.mockCall(
+      address(strategy),
+      abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
+      abi.encode(currPrice * (FULL_ALLOC - maxDecrease) / FULL_ALLOC)
+    );
+
+    uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
+    uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
+    // juniors lost 100% as they need to cover seniors
+    assertEq(1, postBBPrice, 'Full loss for junior tranche');
+    // seniors are covered
+    assertApproxEqAbs(
+      preAAPrice * 97000/100000,
+      postAAPrice, 
+      1000, // 1000 wei to account for interest accrued
+      'AA price lost about 3% (2% covered by junior)'
+    );
+    assertEq(idleCDO.priceAA(), preAAPrice, 'AA price not updated until new interaction');
+    assertEq(idleCDO.priceBB(), preBBPrice, 'BB price not updated until new interaction');
+
+    address newUser = address(123456);
+    deal(address(underlying), newUser, amount * 2);
+    // do another interaction to effectively update prices and trigger default
+    vm.startPrank(newUser);
+    // both deposits will revert as loss will accrue and leave 0 to juniors
+    underlying.approve(address(idleCDO), amount * 2);
+    vm.expectRevert(bytes("4"));
+    idleCDO.depositAA(amount);
+    vm.expectRevert(bytes("4"));
+    idleCDO.depositBB(amount);
+    vm.expectRevert(bytes("4"));
+    idleCDO.withdrawAA(amount);
+    vm.expectRevert(bytes("4"));
+    idleCDO.withdrawBB(amount);
+    vm.stopPrank();
+
+    vm.prank(idleCDO.owner());
+    IdleCDOAutoLossVariant(address(idleCDO)).updateAccounting();
+    // loss is now distributed and shutdown triggered
+
+    uint256 postDepositAAPrice = idleCDO.virtualPrice(address(AAtranche));
+    uint256 postDepositBBPrice = idleCDO.virtualPrice(address(BBtranche));
+
+    assertEq(postDepositAAPrice, postAAPrice, 'AA price did not change after deposit');
+    assertEq(postDepositBBPrice, postBBPrice, 'BB price did not change after deposit');
+    assertEq(idleCDO.priceAA(), postDepositAAPrice, 'AA saved price updated');
+    assertEq(idleCDO.priceBB(), postDepositBBPrice, 'BB saved price updated');
+    assertEq(idleCDO.unclaimedFees(), unclaimedFees, 'Fees did not increase');
+    assertEq(idleCDO.allowAAWithdraw(), false, 'Default flag for senior set');
+    assertEq(idleCDO.allowBBWithdraw(), false, 'Default flag for senior set');
+    assertEq(idleCDO.lastNAVBB(), IERC20Detailed(address(BBtranche)).totalSupply() / 1e18, 'Default flag for senior set');
+
+    // deposits/redeems are disabled
+    vm.expectRevert(bytes("Pausable: paused"));
+    idleCDO.depositAA(amount);
+    vm.expectRevert(bytes("Pausable: paused"));
+    idleCDO.depositBB(amount);
+    vm.expectRevert(bytes("3"));
+    idleCDO.withdrawAA(amount);
+    vm.expectRevert(bytes("3"));
+    idleCDO.withdrawBB(amount);
+
+    vm.clearMockedCalls();
+  }
+
+  function testCheckMaxDecreaseDefault() external runOnForkingNetwork(MAINNET_CHIANID) {
+    uint256 amount = 10000 * ONE_SCALE;
+    // fee is set to 10% and release block period to 0
+
+    // AA Ratio 98%
+    (uint256 preAAPrice, ) = _doDepositsWithInterest(amount - amount / 50, amount / 50);
+
+    uint256 currPrice = strategy.price();
+    uint256 maxDecrease = IdleCDOAutoLossVariant(address(idleCDO)).maxDecreaseDefault();
+    // now let's simulate a loss by decreasing strategy price
+    // curr price - 10%, this will trigger a default
+    vm.mockCall(
+      address(strategy),
+      abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
+      abi.encode(currPrice * (FULL_ALLOC - maxDecrease * 2) / FULL_ALLOC)
+    );
+
+    uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
+    uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
+    // juniors lost 100% as they need to cover seniors
+    assertEq(1, postBBPrice, 'Full loss for junior tranche');
+    // seniors are covered
+    assertApproxEqAbs(
+      preAAPrice * 92000/100000,
+      postAAPrice, 
+      2000, // 2000 wei to account for interest accrued
+      'AA price lost about 8% (2% covered by junior)'
+    );
+
+    // deposits/redeems are disabled
+    vm.expectRevert(bytes("4"));
+    idleCDO.depositAA(amount);
+    vm.expectRevert(bytes("4"));
+    idleCDO.depositBB(amount);
+    vm.expectRevert(bytes("4"));
+    idleCDO.withdrawAA(amount);
+    vm.expectRevert(bytes("4"));
+    idleCDO.withdrawBB(amount);
+
+    // distribute loss, as non owner
+    vm.startPrank(address(232323));
+    vm.expectRevert(bytes("6"));
+    IdleCDOAutoLossVariant(address(idleCDO)).updateAccounting();
+    vm.stopPrank();
+  
+    // effectively distribute loss
+    vm.prank(idleCDO.owner());
+    IdleCDOAutoLossVariant(address(idleCDO)).updateAccounting();
+
+    assertEq(idleCDO.priceAA(), postAAPrice, 'AA saved price updated');
+    assertEq(idleCDO.priceBB(), 1, 'BB saved price updated');
+
+    vm.clearMockedCalls();
+  }
+
+  function _depositWithUser(address _user, uint256 _amount, bool _isAA) internal {
+    deal(address(underlying), _user, _amount * 2);
+    // do another interaction to effectively update prices
+    vm.startPrank(_user);
+    underlying.safeIncreaseAllowance(address(idleCDO), _amount);
+    if (_isAA) {
+      idleCDO.depositAA(_amount);
+    } else {
+      idleCDO.depositBB(_amount);
+    }
+    vm.stopPrank();
+    vm.roll(block.number + 1);
+  }
+
+  function _doDepositsWithInterest(uint256 aa, uint256 bb) 
+    internal 
+    returns (uint256 priceAA, uint256 priceBB) {
+    vm.startPrank(owner);
+    idleCDO.setReleaseBlocksPeriod(0);
+    idleCDO.setFee(10000);
+    vm.stopPrank();
+
+    idleCDO.depositAA(aa);
+    idleCDO.depositBB(bb);
+
+    // deposit underlyings to the strategy
+    _cdoHarvest(true);
+    // accrue some interest 
+    skip(30 days);
+    vm.roll(block.number + 30 * 7200); // 7 days in blocks, needed for compound
+    // claim and sell rewards
+    _cdoHarvest(false);
+    vm.roll(block.number + 1); // 7 days in blocks
+
+    priceAA = idleCDO.virtualPrice(address(AAtranche));
+    priceBB = idleCDO.virtualPrice(address(BBtranche));
+    assertGt(priceAA, ONE_SCALE, 'AA price is > 1');
+    assertGt(priceBB, ONE_SCALE, 'BB price is > 1');
+  }
+}

--- a/test/foundry/IdleCDOAutoLossVariant.t.sol
+++ b/test/foundry/IdleCDOAutoLossVariant.t.sol
@@ -211,7 +211,7 @@ contract TestIdleCDOAutoLossVariant is TestIdleCDOBase {
     uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
     uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
     // juniors lost 100% as they need to cover seniors
-    assertEq(1, postBBPrice, 'Full loss for junior tranche');
+    assertEq(0, postBBPrice, 'Full loss for junior tranche');
     // seniors are covered
     assertApproxEqAbs(
       preAAPrice * 97000/100000,
@@ -287,7 +287,7 @@ contract TestIdleCDOAutoLossVariant is TestIdleCDOBase {
     uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
     uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
     // juniors lost 100% as they need to cover seniors
-    assertEq(1, postBBPrice, 'Full loss for junior tranche');
+    assertEq(0, postBBPrice, 'Full loss for junior tranche');
     // seniors are covered
     assertApproxEqAbs(
       preAAPrice * 92000/100000,
@@ -317,7 +317,7 @@ contract TestIdleCDOAutoLossVariant is TestIdleCDOBase {
     IdleCDOAutoLossVariant(address(idleCDO)).updateAccounting();
 
     assertEq(idleCDO.priceAA(), postAAPrice, 'AA saved price updated');
-    assertEq(idleCDO.priceBB(), 1, 'BB saved price updated');
+    assertEq(idleCDO.priceBB(), 0, 'BB saved price updated');
 
     vm.clearMockedCalls();
   }


### PR DESCRIPTION
This PR creates an IdleCDO variant to automatically redistribute losses to junior holders if there is enough junior TVL available to cover.

Main scenarios covered:
- if there is a loss on the lending protocol (ie strategy price decrease) **up to** a configurable percentage, the loss is 
    - totally absorbed by junior holders if they have enough TVL
    - otherwise a default error (`4`) is raised and deposits/redeems are blocked
- if there is a loss on the lending protocol (ie strategy price decrease) **more than** the configured percentage all deposits and redeems are blocked and a default error (`4`) is raised
- if there is a loss somewhere not in the lending protocol (ie in our contracts) and the TVL decreases then the same process as above applies, the only difference is that the max decrease percentage is not considered

In any case, once a loss happens, it only gets accounted when new deposits/redeems are made, but in most cases those are blocked. For this reason a protected `updateAccounting` method has been added which should be used to distributed the loss after a default event