### PR TITLE
Claim morpho rewards

### DIFF
--- a/contracts/interfaces/morpho/IRewardsDistributor.sol
+++ b/contracts/interfaces/morpho/IRewardsDistributor.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GNU AGPLv3
+pragma solidity ^0.8.0;
+
+/// @notice This contract allows Morpho users to claim their rewards. This contract is largely inspired by Euler Distributor's contract: https://github.com/euler-xyz/euler-contracts/blob/master/contracts/mining/EulDistributor.sol.
+interface IRewardsDistributor {
+    /// @notice Updates the current merkle tree's root.
+    /// @param _newRoot The new merkle tree's root.
+    function updateRoot(bytes32 _newRoot) external;
+
+    /// @notice Withdraws MORPHO tokens to a recipient.
+    /// @param _to The address of the recipient.
+    /// @param _amount The amount of MORPHO tokens to transfer.
+    function withdrawMorphoTokens(address _to, uint256 _amount) external;
+
+    /// @notice Claims rewards.
+    /// @param _account The address of the claimer.
+    /// @param _claimable The overall claimable amount of token rewards.
+    /// @param _proof The merkle proof that validates this claim.
+    function claim(
+        address _account,
+        uint256 _claimable,
+        bytes32[] calldata _proof
+    ) external;
+}

--- a/contracts/mocks/MockRewardsDistributor.sol
+++ b/contracts/mocks/MockRewardsDistributor.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.10;
+
+import "../interfaces/IERC20Detailed.sol";
+import "../interfaces//morpho/IRewardsDistributor.sol";
+
+contract MockRewardsDistributor is IRewardsDistributor {
+    address internal constant MORPHO = 0x9994E35Db50125E0DF82e4c2dde62496CE330999;
+
+    function updateRoot(bytes32 _newRoot) external {}
+
+    function withdrawMorphoTokens(address _to, uint256 _amount) external {}
+
+    function claim(
+        address _account,
+        uint256 _claimable,
+        bytes32[] calldata /* _proof */
+    ) external {
+        IERC20Detailed(MORPHO).transfer(_account, _claimable);
+    }
+}

--- a/contracts/strategies/morpho/MorphoAaveV2SupplyVaultStrategy.sol
+++ b/contracts/strategies/morpho/MorphoAaveV2SupplyVaultStrategy.sol
@@ -7,8 +7,8 @@ contract MorphoAaveV2SupplyVaultStrategy is MorphoSupplyVaultStrategy {
     /// @dev return always a value which is multiplied by 1e18
     ///     eg for 2% apr -> 2*1e18
     function getApr() external view override returns (uint256 apr) {
-        // The supply rate per year experienced on average on the given market (in WAD).
+        // The supply rate per year experienced on average on the given market (in ray).
         (uint256 ratePerYear, , ) = AAVE_LENS.getAverageSupplyRatePerYear(poolToken);
-        apr = ratePerYear / 1e7;
+        apr = ratePerYear / 1e7; // ratePerYear / 1e9 * 100
     }
 }

--- a/contracts/strategies/morpho/MorphoCompoundSupplyVaultStrategy.sol
+++ b/contracts/strategies/morpho/MorphoCompoundSupplyVaultStrategy.sol
@@ -4,9 +4,43 @@ pragma solidity 0.8.10;
 import "./MorphoSupplyVaultStrategy.sol";
 
 contract MorphoCompoundSupplyVaultStrategy is MorphoSupplyVaultStrategy {
+    using SafeERC20Upgradeable for IERC20Detailed;
+
     /// @notice average number of blocks per year
     /// average block time is 12.06 secs after the merge
     uint256 public constant NBLOCKS_PER_YEAR = 2614925; // 24*365*3600 / 12.06
+
+    function redeemRewards(bytes calldata data)
+        public
+        override
+        onlyIdleCDO
+        nonReentrant
+        returns (uint256[] memory rewards)
+    {
+        address _rewardToken = rewardToken;
+
+        rewards = new uint256[](_rewardToken != address(0) ? 2 : 1);
+
+        // claim MORPHO rewards
+        if (address(distributor) != address(0) && data.length != 0) {
+            (uint256 claimable, bytes32[] memory proof) = abi.decode(data, (uint256, bytes32[]));
+
+            uint256 claimed = _claimMorpho(claimable, proof);
+            rewards[0] = claimed;
+
+            // transfer MORPHO to idleCDO
+            MORPHO.safeTransfer(idleCDO, claimed);
+        }
+
+        // claim rewards (e.g. COMP)
+        // if rewardToken is not set, skip redeeming rewards
+        if (_rewardToken != address(0)) {
+            uint256 reward = IMorphoSupplyVault(strategyToken).claimRewards(address(this));
+            rewards[1] = reward;
+            // send rewards to the idleCDO
+            IERC20Detailed(_rewardToken).safeTransfer(idleCDO, reward);
+        }
+    }
 
     function getApr() external view override returns (uint256 apr) {
         //  The market's average supply rate per block (in wad).

--- a/contracts/strategies/morpho/MorphoSupplyVaultStrategy.sol
+++ b/contracts/strategies/morpho/MorphoSupplyVaultStrategy.sol
@@ -6,10 +6,15 @@ import "../../interfaces/IERC20Detailed.sol";
 import "../../interfaces/morpho/IMorphoSupplyVault.sol";
 import "../../interfaces/morpho/IMorphoAaveV2Lens.sol";
 import "../../interfaces/morpho/IMorphoCompoundLens.sol";
+import "../../interfaces/morpho/IRewardsDistributor.sol";
 import "../ERC4626Strategy.sol";
 
 abstract contract MorphoSupplyVaultStrategy is ERC4626Strategy {
     using SafeERC20Upgradeable for IERC20Detailed;
+
+    //// @notice MORPHO governance token
+    IERC20Detailed internal constant MORPHO = IERC20Detailed(0x9994E35Db50125E0DF82e4c2dde62496CE330999);
+
     /// @notice address of the Morpho Aave V2 Lens
     IMorphoAaveV2Lens public AAVE_LENS;
     /// @notice address of the Morpho Compound Lens
@@ -19,36 +24,45 @@ abstract contract MorphoSupplyVaultStrategy is ERC4626Strategy {
     address public poolToken;
 
     /// @notice reward token address (e.g. COMP)
-    /// @dev set to address(0) to skip `redeemRewards`
     address public rewardToken;
+
+    /// @notice MORPHO reward distributor
+    IRewardsDistributor public distributor;
 
     function initialize(
         address _strategyToken,
         address _token,
         address _owner,
         address _poolToken,
-        address _rewardToken
+        address _rewardToken,
+        address _distributor
     ) public {
         AAVE_LENS = IMorphoAaveV2Lens(0x507fA343d0A90786d86C7cd885f5C49263A91FF4);
         COMPOUND_LENS = IMorphoCompoundLens(0x930f1b46e1D081Ec1524efD95752bE3eCe51EF67);
         _initialize(_strategyToken, _token, _owner);
         poolToken = _poolToken;
         rewardToken = _rewardToken;
+        distributor = IRewardsDistributor(_distributor);
     }
 
     /// @notice redeem the rewards
     /// @return rewards amount of reward that is deposited to the ` strategy`
-    function redeemRewards(bytes calldata) public override onlyIdleCDO nonReentrant returns (uint256[] memory rewards) {
-        address _rewardToken = rewardToken;
+    function redeemRewards(bytes calldata data)
+        public
+        virtual
+        override
+        onlyIdleCDO
+        nonReentrant
+        returns (uint256[] memory rewards)
+    {
+        rewards = new uint256[](rewardToken != address(0) ? 2 : 1);
 
-        // if rewardToken is not set, skip redeeming rewards
-        if (_rewardToken != address(0)) {
-            // claim rewards
-            uint256 rewardsAmount = IMorphoSupplyVault(strategyToken).claimRewards(address(this));
-            rewards = new uint256[](1);
-            rewards[0] = rewardsAmount;
-            // send rewards to the idleCDO
-            IERC20Detailed(_rewardToken).safeTransfer(idleCDO, rewardsAmount);
+        if (address(distributor) != address(0) && data.length != 0) {
+            (uint256 claimable, bytes32[] memory proof) = abi.decode(data, (uint256, bytes32[]));
+            // claim MORPHO rewards
+            rewards[0] = _claimMorpho(claimable, proof); // index 0 is always MORPHO
+            // transfer MORPHO to idleCDO
+            MORPHO.safeTransfer(idleCDO, rewards[0]);
         }
     }
 
@@ -56,13 +70,23 @@ abstract contract MorphoSupplyVaultStrategy is ERC4626Strategy {
         address _rewardToken = rewardToken;
 
         if (_rewardToken != address(0)) {
+            rewards = new address[](2);
+            rewards[0] = address(MORPHO);
+            rewards[1] = _rewardToken;
+        } else {
             rewards = new address[](1);
-            rewards[0] = _rewardToken;
+            rewards[0] = address(MORPHO);
         }
     }
 
     /// @dev set to address(0) to skip `redeemRewards`
     function setRewardToken(address _rewardToken) external onlyOwner {
         rewardToken = _rewardToken;
+    }
+
+    function _claimMorpho(uint256 claimable, bytes32[] memory proof) internal returns (uint256 claimed) {
+        // claim MORPHO by verifying a merkle root
+        distributor.claim(address(this), claimable, proof);
+        claimed = MORPHO.balanceOf(address(this));
     }
 }

--- a/test/foundry/MorphoAaveV2SupplyVaultStrategy.t.sol
+++ b/test/foundry/MorphoAaveV2SupplyVaultStrategy.t.sol
@@ -21,6 +21,11 @@ contract TestMorphoAaveV2SupplyVaultStrategy is TestIdleCDOBase {
     address internal constant morphoProxy = 0x777777c9898D384F785Ee44Acfe945efDFf5f3E0;
     address internal constant morphoDistributor = 0x60345417a227ad7E312eAa1B5EC5CD1Fe5E2Cdc6;
 
+    function setUp() public override {
+        vm.selectFork(vm.createFork(vm.envString("ETH_RPC_URL"), 16917511));
+        super.setUp();
+    }
+
     function _deployStrategy(address _owner)
         internal
         override

--- a/test/foundry/MorphoCompoundSupplyVaultStrategy.t.sol
+++ b/test/foundry/MorphoCompoundSupplyVaultStrategy.t.sol
@@ -23,7 +23,7 @@ contract TestMorphoCompoundSupplyVaultStrategy is TestIdleCDOBase {
     address internal constant morphoDistributor = 0x60345417a227ad7E312eAa1B5EC5CD1Fe5E2Cdc6;
 
     // COMP token
-    address internal rewardToken = 0xfa5E1B628EFB17C024ca76f65B45Faf6B3128CA5;
+    address internal rewardToken = 0xc00e94Cb662C3520282E6f5717214004A7f26888;
 
     address internal constant COMP_LENS = 0x930f1b46e1D081Ec1524efD95752bE3eCe51EF67;
 
@@ -44,7 +44,7 @@ contract TestMorphoCompoundSupplyVaultStrategy is TestIdleCDOBase {
             _underlying,
             _owner,
             CDAI,
-            address(0),
+            rewardToken,
             morphoDistributor
         );
 
@@ -151,7 +151,7 @@ contract TestMorphoCompoundSupplyVaultStrategy is TestIdleCDOBase {
         uint256 pricePost = idleCDO.virtualPrice(address(AAtranche));
         // NOTE: right now MORPHO is not transferable
         assertGt(IERC20Detailed(MORPHO).balanceOf(address(idleCDO)), 0, "morpho bal");
-        assertEq(pricePost, pricePre, "virtual price equal");
+        assertGt(pricePost, pricePre, "virtual price increased");
     }
 
     function _cdoHarvest(bool _skipRewards) internal override {

--- a/test/foundry/MorphoCompoundSupplyVaultStrategy.t.sol
+++ b/test/foundry/MorphoCompoundSupplyVaultStrategy.t.sol
@@ -13,10 +13,13 @@ contract TestMorphoCompoundSupplyVaultStrategy is TestIdleCDOBase {
 
     address internal constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
     address internal constant CDAI = 0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643;
+    address internal constant MORPHO = 0x9994E35Db50125E0DF82e4c2dde62496CE330999;
+
     // Morpho-Compound Dai Stablecoin Supply Vault
     // https://github.com/morpho-dao/morpho-tokenized-vaults
     address internal constant mcDAI = 0x8F88EaE3e1c01d60bccdc3DB3CBD5362Dd55d707;
     address internal constant morphoProxy = 0x777777c9898D384F785Ee44Acfe945efDFf5f3E0;
+    address internal constant morphoDistributor = 0x60345417a227ad7E312eAa1B5EC5CD1Fe5E2Cdc6;
 
     address internal constant COMP_LENS = 0x930f1b46e1D081Ec1524efD95752bE3eCe51EF67;
 
@@ -34,7 +37,8 @@ contract TestMorphoCompoundSupplyVaultStrategy is TestIdleCDOBase {
             _underlying,
             _owner,
             CDAI,
-            address(0)
+            address(0),
+            morphoDistributor
         );
 
         vm.label(morphoProxy, "MorphoProxy");
@@ -67,12 +71,12 @@ contract TestMorphoCompoundSupplyVaultStrategy is TestIdleCDOBase {
         assertGt(strategy.price(), strategyPrice, "strategy price");
         // claim rewards
         _cdoHarvest(false);
-        assertEq(underlying.balanceOf(address(idleCDO)), 0, "underlying bal after harvest");    
+        assertEq(underlying.balanceOf(address(idleCDO)), 0, "underlying bal after harvest");
 
         // Skip 7 day forward to accrue interest
         skip(7 days);
         vm.roll(block.number + _strategyReleaseBlocksPeriod() + 1);
-        
+
         // Poke morpho contract with a deposit to increase strategyPrice
         _pokeMorpho();
         assertGt(strategy.price(), strategyPrice, "strategy price");
@@ -88,7 +92,8 @@ contract TestMorphoCompoundSupplyVaultStrategy is TestIdleCDOBase {
             address(underlying),
             owner,
             CDAI,
-            address(0)
+            address(0),
+            morphoDistributor
         );
     }
 
@@ -99,6 +104,6 @@ contract TestMorphoCompoundSupplyVaultStrategy is TestIdleCDOBase {
         vm.startPrank(user);
         IERC20Detailed(DAI).approve(mcDAI, type(uint256).max);
         IERC4626(mcDAI).deposit(userAmount, user);
-        vm.stopPrank();  
+        vm.stopPrank();
     }
 }

--- a/test/foundry/MorphoCompoundSupplyVaultStrategy.t.sol
+++ b/test/foundry/MorphoCompoundSupplyVaultStrategy.t.sol
@@ -27,6 +27,11 @@ contract TestMorphoCompoundSupplyVaultStrategy is TestIdleCDOBase {
 
     address internal constant COMP_LENS = 0x930f1b46e1D081Ec1524efD95752bE3eCe51EF67;
 
+    function setUp() public override {
+        vm.selectFork(vm.createFork(vm.envString("ETH_RPC_URL"), 16917511));
+        super.setUp();
+    }
+
     function _deployStrategy(address _owner) internal override returns (address _strategy, address _underlying) {
         _underlying = DAI;
         strategyToken = IERC20Detailed(mcDAI);

--- a/test/foundry/TestIdleCDOBase.sol
+++ b/test/foundry/TestIdleCDOBase.sol
@@ -386,7 +386,7 @@ abstract contract TestIdleCDOBase is Test {
     );
   }
 
-  function _cdoHarvest(bool _skipRewards) internal {
+  function _cdoHarvest(bool _skipRewards) internal virtual {
     uint256 numOfRewards = rewards.length;
     bool[] memory _skipFlags = new bool[](4);
     bool[] memory _skipReward = new bool[](numOfRewards);


### PR DESCRIPTION
## Changes
 - fix misleading comments
 - for morpho-compound, claim MORPHO and COMP rewards at the time of harvest
 - for morpho-compound, claim MORPHO reward at the time of harvest
## Tests
 - [x] test pass (MorphoCompoundSupplyVaultStrategy)
 - [x] test pass (MorphoAaveSupplyVaultStrategy)


```
Test result: FAILED. 12 passed; 2 failed; finished in 55.21s

Failing tests:
Encountered 2 failing tests in test/foundry/MorphoCompoundSupplyVaultStrategy.t.sol:TestMorphoCompoundSupplyVaultStrategy
[FAIL. Reason: Assertion failed.] testRedeemRewards() (gas: 1084441)
[FAIL. Reason: Assertion failed.] testRedeems() (gas: 2067748)
```

## Checks
- [x] compatible storage layout. (manually checked)