### PR TITLE
Euler incident updates

### DIFF
--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -5796,111 +5796,146 @@
       "layout": {
         "storage": [
           {
-            "contract": "Initializable",
             "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
             "type": "t_bool",
+            "contract": "Initializable",
             "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:25"
           },
           {
-            "contract": "Initializable",
             "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
             "type": "t_bool",
+            "contract": "Initializable",
             "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:30"
           },
           {
-            "contract": "ContextUpgradeable",
             "label": "__gap",
+            "offset": 0,
+            "slot": "1",
             "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
             "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
           },
           {
-            "contract": "OwnableUpgradeable",
             "label": "_owner",
+            "offset": 0,
+            "slot": "51",
             "type": "t_address",
+            "contract": "OwnableUpgradeable",
             "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
           },
           {
-            "contract": "OwnableUpgradeable",
             "label": "__gap",
+            "offset": 0,
+            "slot": "52",
             "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
             "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
           },
           {
-            "contract": "ReentrancyGuardUpgradeable",
             "label": "_status",
+            "offset": 0,
+            "slot": "101",
             "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
             "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:37"
           },
           {
-            "contract": "ReentrancyGuardUpgradeable",
             "label": "__gap",
+            "offset": 0,
+            "slot": "102",
             "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
             "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:67"
           },
           {
-            "contract": "IdleEulerStrategy",
             "label": "strategyToken",
+            "offset": 0,
+            "slot": "151",
             "type": "t_address",
+            "contract": "IdleEulerStrategy",
             "src": "contracts/strategies/euler/IdleEulerStrategy.sol:29"
           },
           {
-            "contract": "IdleEulerStrategy",
             "label": "token",
+            "offset": 0,
+            "slot": "152",
             "type": "t_address",
+            "contract": "IdleEulerStrategy",
             "src": "contracts/strategies/euler/IdleEulerStrategy.sol:31"
           },
           {
-            "contract": "IdleEulerStrategy",
             "label": "oneToken",
+            "offset": 0,
+            "slot": "153",
             "type": "t_uint256",
+            "contract": "IdleEulerStrategy",
             "src": "contracts/strategies/euler/IdleEulerStrategy.sol:33"
           },
           {
-            "contract": "IdleEulerStrategy",
             "label": "tokenDecimals",
+            "offset": 0,
+            "slot": "154",
             "type": "t_uint256",
+            "contract": "IdleEulerStrategy",
             "src": "contracts/strategies/euler/IdleEulerStrategy.sol:35"
           },
           {
-            "contract": "IdleEulerStrategy",
             "label": "underlyingToken",
-            "type": "t_contract(IERC20Detailed)9827",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_contract(IERC20Detailed)18764",
+            "contract": "IdleEulerStrategy",
             "src": "contracts/strategies/euler/IdleEulerStrategy.sol:37"
           },
           {
-            "contract": "IdleEulerStrategy",
             "label": "eToken",
-            "type": "t_contract(IEToken)11782",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_contract(IEToken)22030",
+            "contract": "IdleEulerStrategy",
             "src": "contracts/strategies/euler/IdleEulerStrategy.sol:39"
           },
           {
-            "contract": "IdleEulerStrategy",
             "label": "whitelistedCDO",
+            "offset": 0,
+            "slot": "157",
             "type": "t_address",
+            "contract": "IdleEulerStrategy",
             "src": "contracts/strategies/euler/IdleEulerStrategy.sol:49"
           }
         ],
         "types": {
           "t_address": {
-            "label": "address"
-          },
-          "t_uint256": {
-            "label": "uint256"
-          },
-          "t_contract(IERC20Detailed)9827": {
-            "label": "contract IERC20Detailed"
-          },
-          "t_contract(IEToken)11782": {
-            "label": "contract IEToken"
+            "label": "address",
+            "numberOfBytes": "20"
           },
           "t_array(t_uint256)49_storage": {
-            "label": "uint256[49]"
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
           },
           "t_array(t_uint256)50_storage": {
-            "label": "uint256[50]"
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
           },
           "t_bool": {
-            "label": "bool"
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IERC20Detailed)18764": {
+            "label": "contract IERC20Detailed",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IEToken)22030": {
+            "label": "contract IEToken",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
           }
         }
       }
@@ -17689,6 +17724,791 @@
           },
           "t_bool": {
             "label": "bool"
+          }
+        }
+      }
+    },
+    "5c4ee156831ded27b22dc27222cf5cb87ce114aee5676a642b4f58bbb7a19361": {
+      "address": "0xBA6F9a90CCD403B815eAd85b03e5a93286c66B3B",
+      "txHash": "0x6cb3dd36cd466d401af12819188cade417255965e26e82a1a1831a8429672038",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:25"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:30"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:37"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:67"
+          },
+          {
+            "label": "strategyToken",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "IdleEulerStrategy",
+            "src": "contracts/strategies/euler/IdleEulerStrategy.sol:29"
+          },
+          {
+            "label": "token",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "IdleEulerStrategy",
+            "src": "contracts/strategies/euler/IdleEulerStrategy.sol:31"
+          },
+          {
+            "label": "oneToken",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_uint256",
+            "contract": "IdleEulerStrategy",
+            "src": "contracts/strategies/euler/IdleEulerStrategy.sol:33"
+          },
+          {
+            "label": "tokenDecimals",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_uint256",
+            "contract": "IdleEulerStrategy",
+            "src": "contracts/strategies/euler/IdleEulerStrategy.sol:35"
+          },
+          {
+            "label": "underlyingToken",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_contract(IERC20Detailed)18876",
+            "contract": "IdleEulerStrategy",
+            "src": "contracts/strategies/euler/IdleEulerStrategy.sol:37"
+          },
+          {
+            "label": "eToken",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_contract(IEToken)22142",
+            "contract": "IdleEulerStrategy",
+            "src": "contracts/strategies/euler/IdleEulerStrategy.sol:39"
+          },
+          {
+            "label": "whitelistedCDO",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_address",
+            "contract": "IdleEulerStrategy",
+            "src": "contracts/strategies/euler/IdleEulerStrategy.sol:49"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IERC20Detailed)18876": {
+            "label": "contract IERC20Detailed",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IEToken)22142": {
+            "label": "contract IEToken",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        }
+      }
+    },
+    "7006f851f091c9984854be94dbbfca435b6030af4fce4a0ebc4e4f81836cb69d": {
+      "address": "0x2A719C74e3530D70711b4F4a34B7bc05984601E6",
+      "txHash": "0x27cf4e4d2833b8437c6fbfd6fbf75ab49e38715f1d927eab06694428402a7f81",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:25"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:30"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:34"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:36"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:38"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:40"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:309"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:37"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:67"
+          },
+          {
+            "label": "token",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_address",
+            "contract": "BaseStrategy",
+            "src": "contracts/strategies/BaseStrategy.sol:27"
+          },
+          {
+            "label": "strategyToken",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_address",
+            "contract": "BaseStrategy",
+            "src": "contracts/strategies/BaseStrategy.sol:30"
+          },
+          {
+            "label": "tokenDecimals",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_uint256",
+            "contract": "BaseStrategy",
+            "src": "contracts/strategies/BaseStrategy.sol:33"
+          },
+          {
+            "label": "oneToken",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_uint256",
+            "contract": "BaseStrategy",
+            "src": "contracts/strategies/BaseStrategy.sol:36"
+          },
+          {
+            "label": "underlyingToken",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_contract(IERC20Detailed)18876",
+            "contract": "BaseStrategy",
+            "src": "contracts/strategies/BaseStrategy.sol:39"
+          },
+          {
+            "label": "idleCDO",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_address",
+            "contract": "BaseStrategy",
+            "src": "contracts/strategies/BaseStrategy.sol:42"
+          },
+          {
+            "label": "totalTokensStaked",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_uint256",
+            "contract": "BaseStrategy",
+            "src": "contracts/strategies/BaseStrategy.sol:45"
+          },
+          {
+            "label": "totalTokensLocked",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_uint256",
+            "contract": "BaseStrategy",
+            "src": "contracts/strategies/BaseStrategy.sol:48"
+          },
+          {
+            "label": "lastIndexedTime",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_uint256",
+            "contract": "BaseStrategy",
+            "src": "contracts/strategies/BaseStrategy.sol:51"
+          },
+          {
+            "label": "latestHarvestBlock",
+            "offset": 0,
+            "slot": "210",
+            "type": "t_uint128",
+            "contract": "BaseStrategy",
+            "src": "contracts/strategies/BaseStrategy.sol:55"
+          },
+          {
+            "label": "lastApr",
+            "offset": 16,
+            "slot": "210",
+            "type": "t_uint96",
+            "contract": "BaseStrategy",
+            "src": "contracts/strategies/BaseStrategy.sol:58"
+          },
+          {
+            "label": "releaseBlocksPeriod",
+            "offset": 28,
+            "slot": "210",
+            "type": "t_uint32",
+            "contract": "BaseStrategy",
+            "src": "contracts/strategies/BaseStrategy.sol:61"
+          },
+          {
+            "label": "eToken",
+            "offset": 0,
+            "slot": "211",
+            "type": "t_contract(IEToken)22142",
+            "contract": "IdleEulerStakingStrategy",
+            "src": "contracts/strategies/euler/IdleEulerStakingStrategy.sol:39"
+          },
+          {
+            "label": "stakingRewards",
+            "offset": 0,
+            "slot": "212",
+            "type": "t_contract(IStakingRewards)20376",
+            "contract": "IdleEulerStakingStrategy",
+            "src": "contracts/strategies/euler/IdleEulerStakingStrategy.sol:40"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IERC20Detailed)18876": {
+            "label": "contract IERC20Detailed",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IEToken)22142": {
+            "label": "contract IEToken",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IStakingRewards)20376": {
+            "label": "contract IStakingRewards",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_uint128": {
+            "label": "uint128",
+            "numberOfBytes": "16"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint96": {
+            "label": "uint96",
+            "numberOfBytes": "12"
+          }
+        }
+      }
+    },
+    "fc1b9e096baf68c9337c493dc914dfc6d9c695b5bf2b519ba8ce3b8540e819ed": {
+      "address": "0xc177760cfb98b021338c09afa728882d8c1AcbEA",
+      "txHash": "0x0bc7155413c587c97e83b05f6afb28faf79c8b48695030d6689985cc28a46182",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:25"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:30"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "_paused",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:28"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:96"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "ReentrancyGuardUpgradeable",
+            "label": "_status",
+            "type": "t_uint256",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:37"
+          },
+          {
+            "contract": "ReentrancyGuardUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:67"
+          },
+          {
+            "contract": "GuardedLaunchUpgradable",
+            "label": "limit",
+            "type": "t_uint256",
+            "src": "contracts/GuardedLaunchUpgradable.sol:23"
+          },
+          {
+            "contract": "GuardedLaunchUpgradable",
+            "label": "governanceRecoveryFund",
+            "type": "t_address",
+            "src": "contracts/GuardedLaunchUpgradable.sol:25"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "_lastCallerBlock",
+            "type": "t_bytes32",
+            "src": "contracts/IdleCDOStorage.sol:14"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "latestHarvestBlock",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:16"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "weth",
+            "type": "t_address",
+            "src": "contracts/IdleCDOStorage.sol:18"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "incentiveTokens",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/IdleCDOStorage.sol:20"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "token",
+            "type": "t_address",
+            "src": "contracts/IdleCDOStorage.sol:22"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "guardian",
+            "type": "t_address",
+            "src": "contracts/IdleCDOStorage.sol:24"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "oneToken",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:26"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "rebalancer",
+            "type": "t_address",
+            "src": "contracts/IdleCDOStorage.sol:28"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "uniswapRouterV2",
+            "type": "t_contract(IUniswapV2Router02)2006",
+            "src": "contracts/IdleCDOStorage.sol:30"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "allowAAWithdraw",
+            "type": "t_bool",
+            "src": "contracts/IdleCDOStorage.sol:33"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "allowBBWithdraw",
+            "type": "t_bool",
+            "src": "contracts/IdleCDOStorage.sol:35"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "revertIfTooLow",
+            "type": "t_bool",
+            "src": "contracts/IdleCDOStorage.sol:38"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "skipDefaultCheck",
+            "type": "t_bool",
+            "src": "contracts/IdleCDOStorage.sol:40"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "strategy",
+            "type": "t_address",
+            "src": "contracts/IdleCDOStorage.sol:43"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "strategyToken",
+            "type": "t_address",
+            "src": "contracts/IdleCDOStorage.sol:45"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "AATranche",
+            "type": "t_address",
+            "src": "contracts/IdleCDOStorage.sol:47"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "BBTranche",
+            "type": "t_address",
+            "src": "contracts/IdleCDOStorage.sol:49"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "AAStaking",
+            "type": "t_address",
+            "src": "contracts/IdleCDOStorage.sol:51"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "BBStaking",
+            "type": "t_address",
+            "src": "contracts/IdleCDOStorage.sol:53"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "trancheAPRSplitRatio",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:57"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "trancheIdealWeightRatio",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:60"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "priceAA",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:62"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "priceBB",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:64"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "lastNAVAA",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:66"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "lastNAVBB",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:68"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "lastStrategyPrice",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:70"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "unclaimedFees",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:72"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "unlentPerc",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:74"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "fee",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:77"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "feeReceiver",
+            "type": "t_address",
+            "src": "contracts/IdleCDOStorage.sol:79"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "idealRange",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:82"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "releaseBlocksPeriod",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:84"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "harvestedRewards",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:86"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "isStkAAVEActive",
+            "type": "t_bool",
+            "src": "contracts/IdleCDOStorage.sol:92"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "referral",
+            "type": "t_address",
+            "src": "contracts/IdleCDOStorage.sol:94"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "feeSplit",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:96"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "isAYSActive",
+            "type": "t_bool",
+            "src": "contracts/IdleCDOStorage.sol:99"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "liquidationTolerance",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:108"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "minAprSplitAYS",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:114"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "maxDecreaseDefault",
+            "type": "t_uint256",
+            "src": "contracts/IdleCDOStorage.sol:116"
+          },
+          {
+            "contract": "IdleCDOStorage",
+            "label": "__gap",
+            "type": "t_array(t_uint256)48_storage",
+            "src": "contracts/IdleCDOStorage.sol:130"
+          }
+        ],
+        "types": {
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_contract(IUniswapV2Router02)2006": {
+            "label": "contract IUniswapV2Router02"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
           }
         }
       }

--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -18512,6 +18512,300 @@
           }
         }
       }
+    },
+    "973d43d0d3813a7c5931ef94eac28bedaf176001de455dd8d8f74c4ad8029c98": {
+      "address": "0x15bb111f1b7C60B5f97045c1E817878E8EBD218B",
+      "txHash": "0x1d061f8e47429188e7f3332287766b979c479a511af031f67da6a1951d31a00a",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:25"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:30"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:34"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:36"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:38"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "54",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:40"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "55",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "56",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:309"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:37"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:67"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:28"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:96"
+          },
+          {
+            "label": "token",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_address",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:29"
+          },
+          {
+            "label": "rebalancer",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_address",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:31"
+          },
+          {
+            "label": "feeAddress",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_address",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:33"
+          },
+          {
+            "label": "tokenDecimals",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_uint256",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:35"
+          },
+          {
+            "label": "maxUnlentPerc",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_uint256",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:37"
+          },
+          {
+            "label": "fee",
+            "offset": 0,
+            "slot": "256",
+            "type": "t_uint256",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:39"
+          },
+          {
+            "label": "allAvailableTokens",
+            "offset": 0,
+            "slot": "257",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:41"
+          },
+          {
+            "label": "lastAllocations",
+            "offset": 0,
+            "slot": "258",
+            "type": "t_array(t_uint256)dyn_storage",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:44"
+          },
+          {
+            "label": "protocolWrappers",
+            "offset": 0,
+            "slot": "259",
+            "type": "t_mapping(t_address,t_address)",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:46"
+          },
+          {
+            "label": "_minterBlock",
+            "offset": 0,
+            "slot": "260",
+            "type": "t_bytes32",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:48"
+          },
+          {
+            "label": "lastRebalancerAllocations",
+            "offset": 0,
+            "slot": "261",
+            "type": "t_array(t_uint256)dyn_storage",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:56"
+          },
+          {
+            "label": "lastNAV",
+            "offset": 0,
+            "slot": "262",
+            "type": "t_uint256",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:59"
+          },
+          {
+            "label": "unclaimedFees",
+            "offset": 0,
+            "slot": "263",
+            "type": "t_uint256",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:61"
+          },
+          {
+            "label": "skipRedeemMinAmount",
+            "offset": 0,
+            "slot": "264",
+            "type": "t_bool",
+            "contract": "IdleTokenFungible",
+            "src": "contracts/IdleTokenFungible.sol:64"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        }
+      }
     }
   }
 }

--- a/contracts/IdleCDO.sol
+++ b/contracts/IdleCDO.sol
@@ -8,6 +8,8 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeab
 
 import "./interfaces/IIdleCDOStrategy.sol";
 import "./interfaces/IERC20Detailed.sol";
+import "./interfaces/IIdleCDOTrancheRewards.sol";
+import "./interfaces/IStakedAave.sol";
 
 import "./GuardedLaunchUpgradable.sol";
 import "./IdleCDOTranche.sol";
@@ -51,14 +53,14 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
   /// @param _strategy strategy address
   /// @param _trancheAPRSplitRatio trancheAPRSplitRatio value
   /// @param // deprecated
-  /// @param // deprecated _incentiveTokens array of addresses for incentive tokens
+  /// @param _incentiveTokens array of addresses for incentive tokens
   function initialize(
     uint256 _limit, address _guardedToken, address _governanceFund, address _owner, // GuardedLaunch args
     address _rebalancer,
     address _strategy,
     uint256 _trancheAPRSplitRatio, // for AA tranches, so eg 10000 means 10% interest to AA and 90% BB
     uint256, // Deprecated
-    address[] memory // Deprecated
+    address[] memory _incentiveTokens
   ) external initializer {
     require(token == address(0), '1');
     require(_rebalancer != address(0) && _strategy != address(0) && _guardedToken != address(0), "0");
@@ -84,7 +86,7 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     oneToken = _oneToken;
     uniswapRouterV2 = IUniswapV2Router02(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
     weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
-    // incentiveTokens = _incentiveTokens; [DEPRECATED]
+    incentiveTokens = _incentiveTokens;
     priceAA = _oneToken;
     priceBB = _oneToken;
     unlentPerc = 2000; // 2%
@@ -101,18 +103,17 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     // Save current strategy price
     lastStrategyPrice = _strategyPrice();
     // Fee params
-    fee = 15000; // 15% performance fee
+    fee = 15000; // 10% performance fee
     feeReceiver = address(0xFb3bD022D5DAcF95eE28a6B07825D4Ff9C5b3814); // treasury multisig
     guardian = _owner;
     // feeSplit = 0; // default all to feeReceiver
     isAYSActive = true; // adaptive yield split
     minAprSplitAYS = AA_RATIO_LIM_DOWN; // AA tranche will get min 50% of the yield
 
-    maxDecreaseDefault = 5000; // 5% decrease for triggering a default
     _additionalInit();
   }
 
-  /// @notice used by child contracts (cdo variants) if anything needs to be done on/after init
+  /// @notice used by child contracts if anything needs to be done on/after init
   function _additionalInit() internal virtual {}
 
   // ###############
@@ -174,20 +175,20 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
   // ###############
 
   /// @param _tranche tranche address
-  /// @return tranche price, in underlyings, at the last interaction (not considering interest earned 
-  /// since last interaction)
+  /// @return tranche price
   function tranchePrice(address _tranche) external view returns (uint256) {
     return _tranchePrice(_tranche);
   }
 
-  /// @notice calculates the current net TVL (in `token` terms)
-  /// @dev unclaimed rewards (gov tokens) and `unclaimedFees` are not counted. 
-  /// Harvested rewards are counted only if enough blocks have passed (`_lockedRewards`)
+  /// @notice calculates the current total value locked (in `token` terms)
+  /// @dev unclaimed rewards (gov tokens) are not counted.
+  /// NOTE: `unclaimedFees` are not included in the contract value
+  /// NOTE2: fees that *will* be taken (in the next _updateAccounting call) are counted
   function getContractValue() public override view returns (uint256) {
     address _strategyToken = strategyToken;
     uint256 strategyTokenDecimals = IERC20Detailed(_strategyToken).decimals();
-    // TVL is the sum of unlent balance in the contract + the balance in lending - harvested but locked rewards - unclaimedFees
-    // Balance in lending is the value of the interest bearing assets (strategyTokens) in this contract
+    // TVL is the sum of unlent balance in the contract + the balance in lending - the reduction for harvested rewards - unclaimedFees
+    // the balance in lending is the value of the interest bearing assets (strategyTokens) in this contract
     // TVL = (strategyTokens * strategy token price) + unlent balance - lockedRewards - unclaimedFees
     return (_contractTokenBalance(_strategyToken) * _strategyPrice() / (10**(strategyTokenDecimals))) +
             _contractTokenBalance(token) -
@@ -210,16 +211,18 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     return _getAARatio(false);
   }
 
-  /// @notice calculates the current tranches price considering the interest/loss that is yet to be splitted
-  /// ie the interest/loss generated since the last update of priceAA and priceBB (done on depositXX/withdrawXX/harvest)
+  /// @notice calculates the current tranches price considering the interest that is yet to be splitted
+  /// ie the interest generated since the last update of priceAA and priceBB (done on depositXX/withdrawXX/harvest)
+  /// useful for showing updated gains on frontends
+  /// @dev this should always be >= of _tranchePrice(_tranche)
   /// @param _tranche address of the requested tranche
-  /// @return _virtualPrice tranche price considering all interest/losses
+  /// @return _virtualPrice tranche price considering all interest
   function virtualPrice(address _tranche) public virtual view returns (uint256 _virtualPrice) {
     // get both NAVs, because we need the total NAV anyway
     uint256 _lastNAVAA = lastNAVAA;
     uint256 _lastNAVBB = lastNAVBB;
 
-    (_virtualPrice, ) = _virtualPriceAux(
+    (_virtualPrice, ) = _virtualPricesAux(
       _tranche,
       getContractValue(), // nav
       _lastNAVAA + _lastNAVBB, // lastNAV
@@ -228,7 +231,7 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     );
   }
 
-  /// @notice [DEPRECATED]
+  /// @notice returns an array of tokens used to incentive tranches via IIdleCDOTrancheRewards
   /// @return array with addresses of incentiveTokens (can be empty)
   function getIncentiveTokens() external view returns (address[] memory) {
     return incentiveTokens;
@@ -273,7 +276,7 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
   }
 
   /// @notice this method is called on depositXX/withdrawXX/harvest and
-  /// updates the accounting of the contract and effectively splits the yield/loss between the
+  /// updates the accounting of the contract and effectively splits the yield between the
   /// AA and BB tranches
   /// @dev this method:
   /// - update tranche prices (priceAA and priceBB)
@@ -285,27 +288,17 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     uint256 _lastNAV = _lastNAVAA + _lastNAVBB;
     uint256 nav = getContractValue();
     uint256 _aprSplitRatio = trancheAPRSplitRatio;
+
     // If gain is > 0, then collect some fees in `unclaimedFees`
     if (nav > _lastNAV) {
       unclaimedFees += (nav - _lastNAV) * fee / FULL_ALLOC;
     }
-    (uint256 _priceAA, int256 _totalAAGain) = _virtualPriceAux(AATranche, nav, _lastNAV, _lastNAVAA, _aprSplitRatio);
-    (uint256 _priceBB, int256 _totalBBGain) = _virtualPriceAux(BBTranche, nav, _lastNAV, _lastNAVBB, _aprSplitRatio);
-    lastNAVAA = uint256(int256(_lastNAVAA) + _totalAAGain);
 
-    // if we have a loss and it's gte last junior NAV we trigger a default
-    if (_totalBBGain < 0 && -_totalBBGain >= int256(_lastNAVBB)) {
-      // revert with 'default' error (4) if skipDefaultCheck is false, as seniors will have a loss too not covered. 
-      // `updateAccounting` should be manually called to distribute loss
-      require(skipDefaultCheck, "4");
-      // This path will be called when a default happens and guardian calls
-      // `updateAccounting` after setting skipDefaultCheck
-      lastNAVBB = 0;
-      _emergencyShutdown();
-    } else {
-      // we add the gain to last saved NAV
-      lastNAVBB = uint256(int256(_lastNAVBB) + _totalBBGain);
-    }
+    (uint256 _priceAA, uint256 _totalAAGain) = _virtualPricesAux(AATranche, nav, _lastNAV, _lastNAVAA, _aprSplitRatio);
+    (uint256 _priceBB, uint256 _totalBBGain) = _virtualPricesAux(BBTranche, nav, _lastNAV, _lastNAVBB, _aprSplitRatio);
+
+    lastNAVAA += _totalAAGain;
+    lastNAVBB += _totalBBGain;
     priceAA = _priceAA;
     priceBB = _priceBB;
   }
@@ -325,88 +318,57 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     return IdleCDOTranche(_tranche).totalSupply() * _tranchePrice(_tranche) / ONE_TRANCHE_TOKEN;
   }
 
-  /// @notice calculates the current tranches price considering the interest/loss that is yet to be splitted and the
-  /// total gain/loss for a specific tranche
-  /// @dev Main scenarios covered:
-  /// - if there is a loss on the lending protocol (ie strategy price decrease) up to maxDecreaseDefault (_checkDefault method), the loss is
-  ///     - totally absorbed by junior holders if they have enough TVL and deposits/redeems work as normal
-  ///     - otherwise a 'default' error (4) is raised and deposits/redeems are blocked
-  /// - if there is a loss on the lending protocol (ie strategy price decrease) more than maxDecreaseDefault all deposits and redeems 
-  ///   are blocked and a 'default' error (4) is raised
-  /// - if there is a loss somewhere not in the lending protocol (ie in our contracts) and the TVL decreases then the same process as above 
-  ///   applies, the only difference is that maxDecreaseDefault is not considered
-  /// In any case, once a loss happens, it only gets accounted when new deposits/redeems are made, but those are blocked. 
-  /// For this reason a protected updateAccounting method has been added which should be used to distributed the loss after a default event
+  /// @notice calculates the current tranches price considering the interest that is yet to be splitted and the
+  /// total gain for a specific tranche
   /// @param _tranche address of the requested tranche
   /// @param _nav current NAV
   /// @param _lastNAV last saved NAV
   /// @param _lastTrancheNAV last saved tranche NAV
   /// @param _trancheAPRSplitRatio APR split ratio for AA tranche
   /// @return _virtualPrice tranche price considering all interest
-  /// @return _totalTrancheGain (int256) tranche gain/loss since last update
-  function _virtualPriceAux(
+  /// @return _totalTrancheGain tranche gain since last update
+  function _virtualPricesAux(
     address _tranche,
     uint256 _nav,
     uint256 _lastNAV,
     uint256 _lastTrancheNAV,
     uint256 _trancheAPRSplitRatio
-  ) internal view returns (uint256 _virtualPrice, int256 _totalTrancheGain) {
+  ) internal view returns (uint256 _virtualPrice, uint256 _totalTrancheGain) {
+    // If there is no gain return the current price
+    if (_nav <= _lastNAV) {
+      return (_tranchePrice(_tranche), 0);
+    }
+
     // Check if there are tranche holders
     uint256 trancheSupply = IdleCDOTranche(_tranche).totalSupply();
     if (_lastNAV == 0 || trancheSupply == 0) {
       return (oneToken, 0);
     }
-
     // In order to correctly split the interest generated between AA and BB tranche holders
-    // (according to the trancheAPRSplitRatio) we need to know how much interest/loss we gained
+    // (according to the trancheAPRSplitRatio) we need to know how much interest we gained
     // since the last price update (during a depositXX/withdrawXX/harvest)
     // To do that we need to get the current value of the assets in this contract
     // and the last saved one (always during a depositXX/withdrawXX/harvest)
-    // Calculate the total gain/loss
-    int256 totalGain = int256(_nav) - int256(_lastNAV);
-    // If there is no gain/loss return the current price
-    if (totalGain == 0) {
-      return (_tranchePrice(_tranche), 0);
-    }
 
-    // Remove performance fee for gains
-    if (totalGain > 0) {
-      totalGain -= totalGain * int256(fee) / int256(FULL_ALLOC);
-    }
+    // Calculate the total gain
+    uint256 totalGain = _nav - _lastNAV;
+    // Remove performance fee
+    totalGain -= totalGain * fee / FULL_ALLOC;
 
     address _AATranche = AATranche;
-    address _BBTranche = BBTranche;
     bool _isAATranche = _tranche == _AATranche;
     // Get the supply of the other tranche and
     // if it's 0 then give all gain to the current `_tranche` holders
-    if (IdleCDOTranche(_isAATranche ? _BBTranche : _AATranche).totalSupply() == 0) {
+    if (IdleCDOTranche(_isAATranche ? BBTranche : _AATranche).totalSupply() == 0) {
       _totalTrancheGain = totalGain;
     } else {
-      if (totalGain > 0) {
-        // Split the net gain, with precision loss favoring the AA tranche.
-        int256 totalBBGain = totalGain * int256(FULL_ALLOC - _trancheAPRSplitRatio) / int256(FULL_ALLOC);
-        // The new NAV for the tranche is old NAV + total gain for the tranche
-        _totalTrancheGain = _isAATranche ? (totalGain - totalBBGain) : totalBBGain;
-      } else { // totalGain is negative here
-        // Redirect the whole loss (which should be < maxDecreaseDefault) to junior holders
-        int256 _juniorTVL = int256(_isAATranche ? _lastNAV - _lastTrancheNAV : _lastTrancheNAV);
-        int256 _newJuniorTVL = _juniorTVL + totalGain; 
-        // if junior holders have enough TVL to cover
-        if (_newJuniorTVL > 0) {
-          _totalTrancheGain = _isAATranche ? int256(0) : totalGain;
-        } else {
-          // otherwise all loss minus junior tvl to senior
-          if (!_isAATranche) {
-            // juniors have no more claim price is set to 0, gain is set to -juniorTVL
-            return (0, -_juniorTVL);
-          }
-          // seniors get the loss - old junior TVL
-          _totalTrancheGain = _newJuniorTVL;
-        }
-      }
+      // Split the net gain, with precision loss favoring the AA tranche.
+      uint256 totalBBGain = totalGain * (FULL_ALLOC - _trancheAPRSplitRatio) / FULL_ALLOC;
+      // The new NAV for the tranche is old NAV + total gain for the tranche
+      _totalTrancheGain = _isAATranche ? (totalGain - totalBBGain) : totalBBGain;
     }
     // Split the new NAV (_lastTrancheNAV + _totalTrancheGain) per tranche token
-    _virtualPrice = uint256(int256(_lastTrancheNAV) + int256(_totalTrancheGain)) * ONE_TRANCHE_TOKEN / trancheSupply;
+    _virtualPrice = (_lastTrancheNAV + _totalTrancheGain) * ONE_TRANCHE_TOKEN / trancheSupply;
   }
 
   /// @notice mint tranche tokens and updates tranche last NAV
@@ -427,14 +389,29 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
   }
 
   /// @notice convert fees (`unclaimedFees`) in AA tranche tokens
+  /// Tranche tokens are then automatically staked in the relative IdleCDOTrancheRewards contact if present
   /// @dev this will be called only during harvests
   function _depositFees() internal {
     uint256 _amount = unclaimedFees;
     if (_amount > 0) {
-      // mint tranches tokens (always AA) to this contract
-      _mintShares(_amount, feeReceiver, AATranche);
+      address stakingRewards = AAStaking;
+      bool isStakingRewardsActive = stakingRewards != address(0);
+      address _feeReceiver = feeReceiver;
+
+      // mint tranches tokens to this contract
+      uint256 _minted = _mintShares(
+        _amount,
+        isStakingRewardsActive ? address(this) : _feeReceiver,
+        // Mint AA tranche tokens as fees
+        AATranche
+      );
       // reset unclaimedFees counter
       unclaimedFees = 0;
+
+      // auto stake fees in staking contract for feeReceiver
+      if (isStakingRewardsActive) {
+        IIdleCDOTrancheRewards(stakingRewards).stakeFor(_feeReceiver, _minted);
+      }
     }
   }
 
@@ -516,13 +493,11 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     return AABal * FULL_ALLOC / contractVal;
   }
 
-  /// @dev check if _strategyPrice is decreased more than X% with X configurable since last update 
-  /// and updates last saved strategy price
+  /// @dev check if _strategyPrice is decreased since last update and updates last saved strategy price
   function _checkDefault() virtual internal {
     uint256 currPrice = _strategyPrice();
     if (!skipDefaultCheck) {
-      // calculate if % of decrease of strategyPrice is within maxDecreaseDefault
-      require(lastStrategyPrice * (FULL_ALLOC - maxDecreaseDefault) / FULL_ALLOC <= currPrice, "4");
+      require(lastStrategyPrice <= currPrice, "4");
     }
     lastStrategyPrice = currPrice;
   }
@@ -618,6 +593,7 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     internal
     returns (uint256[] memory _soldAmounts, uint256[] memory _swappedAmounts, uint256 _totSold) {
     // Fetch state variables once to save gas
+    address[] memory _incentiveTokens = incentiveTokens;
     // get all rewards addresses
     address[] memory _rewards = _strategy.getRewardTokens();
     address _rewardToken;
@@ -632,7 +608,7 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     for (uint256 i = 0; i < _rewards.length; i++) {
       _rewardToken = _rewards[i];
       // check if it should be sold or not
-      if (_skipReward[i]) { continue; }
+      if (_skipReward[i] || _includesAddress(_incentiveTokens, _rewardToken)) { continue; }
       // do not sell stkAAVE but only AAVE if present
       if (_rewardToken == stkAave) {
         _rewardToken = AAVE;
@@ -691,13 +667,14 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
   // Protected
   // ###################
 
-  /// @notice This method is used to lend user funds in the lending provider through an IIdleCDOStrategy
+  /// @notice This method is used to lend user funds in the lending provider through the IIdleCDOStrategy and update tranches incentives.
   /// The method:
   /// - redeems rewards (if any) from the lending provider
-  /// - converts the rewards in underlyings through uniswap v2 or v3
+  /// - converts the rewards NOT present in the `incentiveTokens` array, in underlyings through uniswap v2
   /// - calls _updateAccounting to update the accounting of the system with the new underlyings received
-  /// - it then convert fees in tranche tokens
-  /// - finally it deposits the (initial unlent balance + the underlyings get from uniswap - fees) in the
+  /// - it then convert fees in tranche tokens and stake tranche tokens in the IdleCDOTrancheRewards if any
+  /// - sends the correct amount of `incentiveTokens` to the each of the IdleCDOTrancheRewards contracts
+  /// - Finally it deposits the (initial unlent balance + the underlyings get from uniswap - fees) in the
   ///   lending provider through the IIdleCDOStrategy `deposit` call
   /// The method will be called by an external, whitelisted, keeper bot which will call the method sistematically (eg once a day)
   /// @dev can be called only by the rebalancer or the owner
@@ -778,14 +755,6 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
   // onlyOwner
   // ###################
 
-  /// @dev automatically reverts if strategyPrice decreased more than `_maxDecreaseDefault`
-  /// @param _maxDecreaseDefault max value, in % where `100000` = 100%, of accettable price decrease for the strategy
-  function setMaxDecreaseDefault(uint256 _maxDecreaseDefault) external {
-    _checkOnlyOwner();
-    require(_maxDecreaseDefault < FULL_ALLOC);
-    maxDecreaseDefault = _maxDecreaseDefault;
-  }
-
   /// @param _active flag to allow Adaptive Yield Split
   function setIsAYSActive(bool _active) external {
     _checkOnlyOwner();
@@ -840,7 +809,7 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     liquidationTolerance = _diff;
   }
 
-  /// @param _aprSplit min apr split for AA, considering FULL_ALLOC = 100%
+  /// @param _aprSplit apr split for AA, considering FULL_ALLOC = 100%
   function setMinAprSplitAYS(uint256 _aprSplit) external {
     _checkOnlyOwner();
     require((minAprSplitAYS = _aprSplit) <= FULL_ALLOC, '7');
@@ -872,17 +841,71 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     require((trancheAPRSplitRatio = _trancheAPRSplitRatio) <= FULL_ALLOC, '7');
   }
 
-  /// @notice this method updates the accounting of the contract and effectively splits the yield/loss between the
-  /// AA and BB tranches. This can be called at any time as is called automatically on each deposit/redeem. It's here
-  /// just to be called when a default happened, as deposits/redeems are paused, but we need to update
-  /// the loss for junior holders
-  function updateAccounting() external {
-    _checkOnlyOwnerOrGuardian();
-    skipDefaultCheck = true;
-    _updateAccounting();
-    // _updateAccounting can set `skipDefaultCheck` to true in case of default
-    // but this can be manually be reset to true if needed
-    skipDefaultCheck = false;
+  /// @dev it's REQUIRED to transfer out any incentive tokens accrued before
+  /// @param _incentiveTokens array with new incentive tokens
+  function setIncentiveTokens(address[] memory _incentiveTokens) external {
+    _checkOnlyOwner();
+    incentiveTokens = _incentiveTokens;
+  }
+
+  /// @notice Set tranche Rewards contract addresses (for tranches incentivization)
+  /// @param _AAStaking IdleCDOTrancheRewards contract address for AA tranches
+  /// @param _BBStaking IdleCDOTrancheRewards contract address for BB tranches
+  function setStakingRewards(address _AAStaking, address _BBStaking) external {
+    _checkOnlyOwner();
+    // Read state variable once
+    address _AATranche = AATranche;
+    address _BBTranche = BBTranche;
+    address[] memory _incentiveTokens = incentiveTokens;
+    address _currAAStaking = AAStaking;
+    address _currBBStaking = BBStaking;
+    bool _isAAStakingActive = _currAAStaking != address(0);
+    bool _isBBStakingActive = _currBBStaking != address(0);
+    address _incentiveToken;
+    // Remove allowance for incentive tokens for current staking contracts
+    for (uint256 i = 0; i < _incentiveTokens.length; i++) {
+      _incentiveToken = _incentiveTokens[i];
+      if (_isAAStakingActive) {
+        _removeAllowance(_incentiveToken, _currAAStaking);
+      }
+      if (_isBBStakingActive) {
+        _removeAllowance(_incentiveToken, _currBBStaking);
+      }
+    }
+    // Remove allowace for tranche tokens (used for staking fees)
+    if (_isAAStakingActive && _AATranche != address(0)) {
+      _removeAllowance(_AATranche, _currAAStaking);
+    }
+    if (_isBBStakingActive && _BBTranche != address(0)) {
+      _removeAllowance(_BBTranche, _currBBStaking);
+    }
+
+    // Update staking contract addresses
+    AAStaking = _AAStaking;
+    BBStaking = _BBStaking;
+
+    _isAAStakingActive = _AAStaking != address(0);
+    _isBBStakingActive = _BBStaking != address(0);
+
+    // Increase allowance for incentiveTokens
+    for (uint256 i = 0; i < _incentiveTokens.length; i++) {
+      _incentiveToken = _incentiveTokens[i];
+      // Approve each staking contract to spend each incentiveToken on beahlf of this contract
+      if (_isAAStakingActive) {
+        _allowUnlimitedSpend(_incentiveToken, _AAStaking);
+      }
+      if (_isBBStakingActive) {
+        _allowUnlimitedSpend(_incentiveToken, _BBStaking);
+      }
+    }
+
+    // Increase allowance for tranche tokens (used for staking fees)
+    if (_isAAStakingActive && _AATranche != address(0)) {
+      _allowUnlimitedSpend(_AATranche, _AAStaking);
+    }
+    if (_isBBStakingActive && _BBTranche != address(0)) {
+      _allowUnlimitedSpend(_BBTranche, _BBStaking);
+    }
   }
 
   /// @notice pause deposits and redeems for all classes of tranches
@@ -918,14 +941,14 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     revertIfTooLow = true;
   }
 
-  /// @notice Pauses deposits
+  /// @notice Pauses deposits and redeems
   /// @dev can be called by both the owner and the guardian
   function pause() external  {
     _checkOnlyOwnerOrGuardian();
     _pause();
   }
 
-  /// @notice Unpauses deposits
+  /// @notice Unpauses deposits and redeems
   /// @dev can be called by both the owner and the guardian
   function unpause() external {
     _checkOnlyOwnerOrGuardian();
@@ -975,6 +998,21 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
   /// @dev Check that the second function is not called in the same tx from the same tx.origin
   function _checkSameTx() internal view {
     require(keccak256(abi.encodePacked(tx.origin, block.number)) != _lastCallerBlock, "8");
+  }
+
+  /// @dev this method is only used to check whether a token is an incentive tokens or not
+  /// in the harvest call. The maximum number of element in the array will be a small number (eg at most 3-5)
+  /// @param _array array of addresses to search for an element
+  /// @param _val address of an element to find
+  /// @return flag if the _token is an incentive token or not
+  function _includesAddress(address[] memory _array, address _val) internal pure returns (bool) {
+    for (uint256 i = 0; i < _array.length; i++) {
+      if (_array[i] == _val) {
+        return true;
+      }
+    }
+    // explicit return to fix linter
+    return false;
   }
 
   /// @notice concat 2 strings in a single one

--- a/contracts/strategies/euler/IdleEulerStakingStrategy.sol
+++ b/contracts/strategies/euler/IdleEulerStakingStrategy.sol
@@ -115,23 +115,23 @@ contract IdleEulerStakingStrategy is BaseStrategy {
     /// @param _shares amount of strategyTokens to redeem
     /// @return amountRedeemed  amount of underlyings redeemed
     function redeem(uint256 _shares) external override onlyIdleCDO returns (uint256 amountRedeemed) {
-        if (_shares != 0) {
-            _burn(msg.sender, _shares);
-            // Withdraw amount needed
-            amountRedeemed = _withdraw((_shares * price()) / EXP_SCALE, msg.sender);
-        }
+        // if (_shares != 0) {
+        //     _burn(msg.sender, _shares);
+        //     // Withdraw amount needed
+        //     amountRedeemed = _withdraw((_shares * price()) / EXP_SCALE, msg.sender);
+        // }
     }
 
     /// @notice Redeem Tokens
     /// @param _amount amount of underlying tokens to redeem
     /// @return amountRedeemed Amount of underlying tokens received
     function redeemUnderlying(uint256 _amount) external override onlyIdleCDO returns (uint256 amountRedeemed) {
-        uint256 _shares = (_amount * EXP_SCALE) / price();
-        if (_shares != 0) {
-            _burn(msg.sender, _shares);
-            // Withdraw amount needed
-            amountRedeemed = _withdraw(_amount, msg.sender);
-        }
+        // uint256 _shares = (_amount * EXP_SCALE) / price();
+        // if (_shares != 0) {
+        //     _burn(msg.sender, _shares);
+        //     // Withdraw amount needed
+        //     amountRedeemed = _withdraw(_amount, msg.sender);
+        // }
     }
 
     // ###################
@@ -150,26 +150,26 @@ contract IdleEulerStakingStrategy is BaseStrategy {
         override
         returns (uint256 amountWithdrawn)
     {
-        IEToken _eToken = eToken;
-        IERC20Detailed _underlyingToken = underlyingToken;
-        IStakingRewards _stakingRewards = stakingRewards;
+        // IEToken _eToken = eToken;
+        // IERC20Detailed _underlyingToken = underlyingToken;
+        // IStakingRewards _stakingRewards = stakingRewards;
 
-        if (address(_stakingRewards) != address(0)) {
-            // Unstake from StakingRewards
-            _stakingRewards.withdraw(_eToken.convertUnderlyingToBalance(_amountToWithdraw));
-        }
+        // if (address(_stakingRewards) != address(0)) {
+        //     // Unstake from StakingRewards
+        //     _stakingRewards.withdraw(_eToken.convertUnderlyingToBalance(_amountToWithdraw));
+        // }
 
-        uint256 underlyingsInEuler = _eToken.balanceOfUnderlying(address(this));
-        if (_amountToWithdraw > underlyingsInEuler) {
-            _amountToWithdraw = underlyingsInEuler;
-        }
+        // uint256 underlyingsInEuler = _eToken.balanceOfUnderlying(address(this));
+        // if (_amountToWithdraw > underlyingsInEuler) {
+        //     _amountToWithdraw = underlyingsInEuler;
+        // }
 
-        // Withdraw from Euler
-        uint256 underlyingBalanceBefore = _underlyingToken.balanceOf(address(this));
-        _eToken.withdraw(SUB_ACCOUNT_ID, _amountToWithdraw);
-        amountWithdrawn = _underlyingToken.balanceOf(address(this)) - underlyingBalanceBefore;
-        // Send tokens to the destination
-        _underlyingToken.safeTransfer(_destination, amountWithdrawn);
+        // // Withdraw from Euler
+        // uint256 underlyingBalanceBefore = _underlyingToken.balanceOf(address(this));
+        // _eToken.withdraw(SUB_ACCOUNT_ID, _amountToWithdraw);
+        // amountWithdrawn = _underlyingToken.balanceOf(address(this)) - underlyingBalanceBefore;
+        // // Send tokens to the destination
+        // _underlyingToken.safeTransfer(_destination, amountWithdrawn);
     }
 
     /// @return rewards rewards[0] : rewards redeemed
@@ -191,14 +191,14 @@ contract IdleEulerStakingStrategy is BaseStrategy {
 
     /// @return net price in underlyings of 1 strategyToken
     function price() public view virtual override returns (uint256) {
-        IEToken _eToken = eToken;
-        // if it fails it means that Euler is paused, so it should be safe to set price to 1
-        // as deposits and redeems are not allowed
-        try _eToken.decimals() returns (uint256 _decimals) {
-            return _eToken.convertBalanceToUnderlying(10**_decimals);
-        } catch {
-            return 10**tokenDecimals;
-        }
+        // IEToken _eToken = eToken;
+        // // if it fails it means that Euler is paused, so it should be safe to set price to 1
+        // // as deposits and redeems are not allowed
+        // try _eToken.decimals() returns (uint256 _decimals) {
+        //     return _eToken.convertBalanceToUnderlying(10**_decimals);
+        // } catch {
+        //     return 10**tokenDecimals;
+        // }
     }
     /// @dev Returns supply apr for providing liquidity minus reserveFee
     /// @return apr net apr (fees should already be excluded)

--- a/contracts/strategies/euler/IdleEulerStrategy.sol
+++ b/contracts/strategies/euler/IdleEulerStrategy.sol
@@ -130,11 +130,11 @@ contract IdleEulerStrategy is
         override
         returns (uint256 redeemed)
     {
-        if (_amount > 0) {
-            // get eTokens from the user
-            eToken.transferFrom(msg.sender, address(this), _amount);
-            redeemed = _redeem(eToken.convertBalanceToUnderlying(_amount));
-        }
+        // if (_amount > 0) {
+        //     // get eTokens from the user
+        //     eToken.transferFrom(msg.sender, address(this), _amount);
+        //     redeemed = _redeem(eToken.convertBalanceToUnderlying(_amount));
+        // }
     }
 
     /// @notice Anyone can call this because this contract holds no stETH and so no 'old' rewards
@@ -156,23 +156,23 @@ contract IdleEulerStrategy is
         override
         returns (uint256 redeemed)
     {
-        if (_amount > 0) {
-            // get eTokens from the user
-            eToken.transferFrom(
-                msg.sender,
-                address(this),
-                eToken.convertUnderlyingToBalance(_amount)
-            );
+        // if (_amount > 0) {
+        //     // get eTokens from the user
+        //     eToken.transferFrom(
+        //         msg.sender,
+        //         address(this),
+        //         eToken.convertUnderlyingToBalance(_amount)
+        //     );
 
-            // after converting underlying amount to eToken to collect from user
-            // the underlying amount could exceed eToken balance upon calling withdraw
-            // and revert with 'e/insufficient-balance'
-            if (eToken.balanceOfUnderlying(address(this)) < _amount) {
-                redeemed = _redeem(eToken.balanceOfUnderlying(address(this)));
-            } else {
-                redeemed = _redeem(_amount);
-            }
-        }
+        //     // after converting underlying amount to eToken to collect from user
+        //     // the underlying amount could exceed eToken balance upon calling withdraw
+        //     // and revert with 'e/insufficient-balance'
+        //     if (eToken.balanceOfUnderlying(address(this)) < _amount) {
+        //         redeemed = _redeem(eToken.balanceOfUnderlying(address(this)));
+        //     } else {
+        //         redeemed = _redeem(_amount);
+        //     }
+        // }
     }
 
     // ###################
@@ -180,21 +180,21 @@ contract IdleEulerStrategy is
     // ###################
 
     function _redeem(uint256 _amount) internal returns (uint256 redeemed) {
-        uint256 underlyingTokenBalanceBefore = underlyingToken.balanceOf(
-            address(this)
-        );
+        // uint256 underlyingTokenBalanceBefore = underlyingToken.balanceOf(
+        //     address(this)
+        // );
 
-        eToken.withdraw(0, _amount);
+        // eToken.withdraw(0, _amount);
 
-        uint256 underlyingTokenBalanceAfter = underlyingToken.balanceOf(
-            address(this)
-        );
-        redeemed = underlyingTokenBalanceAfter - underlyingTokenBalanceBefore;
+        // uint256 underlyingTokenBalanceAfter = underlyingToken.balanceOf(
+        //     address(this)
+        // );
+        // redeemed = underlyingTokenBalanceAfter - underlyingTokenBalanceBefore;
 
-        // transfer redeemed underlying tokens to msg.sender
-        underlyingToken.safeTransfer(msg.sender, redeemed);
-        // transfer gov tokens to msg.sender
-        // _withdrawGovToken(msg.sender);
+        // // transfer redeemed underlying tokens to msg.sender
+        // underlyingToken.safeTransfer(msg.sender, redeemed);
+        // // transfer gov tokens to msg.sender
+        // // _withdrawGovToken(msg.sender);
     }
 
     // ###################
@@ -203,32 +203,32 @@ contract IdleEulerStrategy is
 
     /// @return net price in underlyings of 1 strategyToken
     function price() public view override returns (uint256) {
-        uint256 decimals = eToken.decimals();
-        // return price of 1 eToken in underlying
-        return eToken.convertBalanceToUnderlying(10**decimals);
+        // uint256 decimals = eToken.decimals();
+        // // return price of 1 eToken in underlying
+        // return eToken.convertBalanceToUnderlying(10**decimals);
     }
 
     /// @dev Returns supply apr for providing liquidity minus reserveFee
     /// @return apr net apr (fees should already be excluded)
     function getApr() external view override returns (uint256 apr) {
-        // Use the markets module:
-        IMarkets markets = IMarkets(EULER_MARKETS);
-        IDToken dToken = IDToken(markets.underlyingToDToken(token));
-        uint256 borrowSPY = uint256(int256(markets.interestRate(token)));
-        uint256 totalBorrows = dToken.totalSupply();
-        uint256 totalBalancesUnderlying = eToken.totalSupplyUnderlying();
-        uint32 reserveFee = markets.reserveFee(token);
-        // (borrowAPY, supplyAPY)
-        (, apr) = IEulerGeneralView(EULER_GENERAL_VIEW).computeAPYs(
-            borrowSPY,
-            totalBorrows,
-            totalBalancesUnderlying,
-            reserveFee
-        );
-        // apr is eg 0.024300334 * 1e27 for 2.43% apr
-        // while the method needs to return the value in the format 2.43 * 1e18
-        // so we do apr / 1e9 * 100 -> apr / 1e7
-        apr = apr / 1e7;
+        // // Use the markets module:
+        // IMarkets markets = IMarkets(EULER_MARKETS);
+        // IDToken dToken = IDToken(markets.underlyingToDToken(token));
+        // uint256 borrowSPY = uint256(int256(markets.interestRate(token)));
+        // uint256 totalBorrows = dToken.totalSupply();
+        // uint256 totalBalancesUnderlying = eToken.totalSupplyUnderlying();
+        // uint32 reserveFee = markets.reserveFee(token);
+        // // (borrowAPY, supplyAPY)
+        // (, apr) = IEulerGeneralView(EULER_GENERAL_VIEW).computeAPYs(
+        //     borrowSPY,
+        //     totalBorrows,
+        //     totalBalancesUnderlying,
+        //     reserveFee
+        // );
+        // // apr is eg 0.024300334 * 1e27 for 2.43% apr
+        // // while the method needs to return the value in the format 2.43 * 1e18
+        // // so we do apr / 1e9 * 100 -> apr / 1e7
+        // apr = apr / 1e7;
     }
 
     /// @return tokens array of reward token addresses

--- a/test/foundry/IdleCDOLossMgmt.t.sol
+++ b/test/foundry/IdleCDOLossMgmt.t.sol
@@ -1,327 +1,327 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.10;
-import "../../contracts/interfaces/ICToken.sol";
-import "../../contracts/strategies/idle/IdleStrategy.sol";
-import "../../contracts/IdleCDO.sol";
-import "./TestIdleCDOBase.sol";
+// // SPDX-License-Identifier: MIT
+// pragma solidity 0.8.10;
+// import "../../contracts/interfaces/ICToken.sol";
+// import "../../contracts/strategies/idle/IdleStrategy.sol";
+// import "../../contracts/IdleCDO.sol";
+// import "./TestIdleCDOBase.sol";
 
-// @notice: These tests are exclusively for the IdleCDO loss mgmt, these are separate from TestIdleCDOBase
-// so to avoid having to simulate losses in all derived tests. Tests are with an IdleCDO that deposits 
-// in idleUSDC.
-// @dev: IMPORTANT tests are made at block 16368877 where idleUSDC had all deposited in compound
-// this is crucial for the test as to mock a default we decrease `exchangeRateStored` of the corresponding
-// cToken associated with the idleToken. If another block is used make sure to mock the correct call.
-// It's not enough to mock strategy.price() otherwise on redeems the wrong number of strategyTokens will be burned
+// // @notice: These tests are exclusively for the IdleCDO loss mgmt, these are separate from TestIdleCDOBase
+// // so to avoid having to simulate losses in all derived tests. Tests are with an IdleCDO that deposits 
+// // in idleUSDC.
+// // @dev: IMPORTANT tests are made at block 16368877 where idleUSDC had all deposited in compound
+// // this is crucial for the test as to mock a default we decrease `exchangeRateStored` of the corresponding
+// // cToken associated with the idleToken. If another block is used make sure to mock the correct call.
+// // It's not enough to mock strategy.price() otherwise on redeems the wrong number of strategyTokens will be burned
 
-contract TestIdleCDOLossMgmt is TestIdleCDOBase {
-  using stdStorage for StdStorage;
-  using SafeERC20Upgradeable for IERC20Detailed;
+// contract TestIdleCDOLossMgmt is TestIdleCDOBase {
+//   using stdStorage for StdStorage;
+//   using SafeERC20Upgradeable for IERC20Detailed;
 
-  // Idle-USDC Best-Yield v4
-  address internal constant UNDERLYING = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
-  address internal constant idleToken = 0x5274891bEC421B39D23760c04A6755eCB444797C;
-  address internal constant cToken = 0x39AA39c021dfbaE8faC545936693aC917d5E7563;
+//   // Idle-USDC Best-Yield v4
+//   address internal constant UNDERLYING = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+//   address internal constant idleToken = 0x5274891bEC421B39D23760c04A6755eCB444797C;
+//   address internal constant cToken = 0x39AA39c021dfbaE8faC545936693aC917d5E7563;
 
-  function _selectFork() public override {
-    // IdleUSDC deposited all in compund
-    vm.selectFork(vm.createFork(vm.envString("ETH_RPC_URL"), 16368877));
-  }
+//   function _selectFork() public override {
+//     // IdleUSDC deposited all in compund
+//     vm.selectFork(vm.createFork(vm.envString("ETH_RPC_URL"), 16368877));
+//   }
 
-  function _deployStrategy(address _owner) internal override returns (address _strategy, address _underlying) {
-    _underlying = UNDERLYING;
-    underlying = IERC20Detailed(_underlying);
-    strategy = new IdleStrategy();
-    _strategy = address(strategy);
-    stdstore.target(_strategy).sig(strategy.token.selector).checked_write(address(0));
-    IdleStrategy(_strategy).initialize(idleToken, _owner);
-  }
+//   function _deployStrategy(address _owner) internal override returns (address _strategy, address _underlying) {
+//     _underlying = UNDERLYING;
+//     underlying = IERC20Detailed(_underlying);
+//     strategy = new IdleStrategy();
+//     _strategy = address(strategy);
+//     stdstore.target(_strategy).sig(strategy.token.selector).checked_write(address(0));
+//     IdleStrategy(_strategy).initialize(idleToken, _owner);
+//   }
 
-  function _postDeploy(address _cdo, address _owner) internal override {
-    vm.prank(_owner);
-    IdleStrategy(address(strategy)).setWhitelistedCDO(address(_cdo));
-  }
+//   function _postDeploy(address _cdo, address _owner) internal override {
+//     vm.prank(_owner);
+//     IdleStrategy(address(strategy)).setWhitelistedCDO(address(_cdo));
+//   }
 
-  function _pokeLendingProtocol() internal override {
-    ICToken(cToken).accrueInterest();
-  }
+//   function _pokeLendingProtocol() internal override {
+//     ICToken(cToken).accrueInterest();
+//   }
 
-  // ###################################
-  // ############ TESTS ################
-  // ###################################
+//   // ###################################
+//   // ############ TESTS ################
+//   // ###################################
 
-  function testOnlyIdleCDO() public override {}
+//   function testOnlyIdleCDO() public override {}
 
-  function testCantReinitialize() external override {
-      vm.expectRevert(bytes("Initializable: contract is already initialized"));
-      IdleStrategy(address(strategy)).initialize(idleToken, owner);
-  }
+//   function testCantReinitialize() external override {
+//       vm.expectRevert(bytes("Initializable: contract is already initialized"));
+//       IdleStrategy(address(strategy)).initialize(idleToken, owner);
+//   }
 
-  function testDepositWithLossCovered() external {
-    uint256 amount = 10000 * ONE_SCALE;
-    // fee is set to 10% and release block period to 0
-    (uint256 preAAPrice, uint256 preBBPrice) = _doDepositsWithInterest(amount, amount);
+//   function testDepositWithLossCovered() external {
+//     uint256 amount = 10000 * ONE_SCALE;
+//     // fee is set to 10% and release block period to 0
+//     (uint256 preAAPrice, uint256 preBBPrice) = _doDepositsWithInterest(amount, amount);
 
-    uint256 currPrice = strategy.price();
-    uint256 maxDecrease = IdleCDO(address(idleCDO)).maxDecreaseDefault();
-    uint256 unclaimedFees = idleCDO.unclaimedFees();
-    // now let's simulate a loss by decreasing strategy price
-    // curr price - 5%
-    vm.mockCall(
-      address(strategy),
-      abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
-      abi.encode(currPrice * (FULL_ALLOC - maxDecrease) / FULL_ALLOC)
-    );
+//     uint256 currPrice = strategy.price();
+//     uint256 maxDecrease = IdleCDO(address(idleCDO)).maxDecreaseDefault();
+//     uint256 unclaimedFees = idleCDO.unclaimedFees();
+//     // now let's simulate a loss by decreasing strategy price
+//     // curr price - 5%
+//     vm.mockCall(
+//       address(strategy),
+//       abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
+//       abi.encode(currPrice * (FULL_ALLOC - maxDecrease) / FULL_ALLOC)
+//     );
 
-    uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
-    uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
-    // juniors lost about 10% as there were seniors to cover
-    assertApproxEqAbs(
-      preBBPrice * 90000/100000,
-      postBBPrice, 
-      200 // 200 wei to account for interest accrued
-    );
-    // seniors are covered
-    assertEq(preAAPrice, postAAPrice, 'AA price unaffected');
-    assertEq(idleCDO.priceAA(), preAAPrice, 'AA price not updated until new interaction');
-    assertEq(idleCDO.priceBB(), preBBPrice, 'BB price not updated until new interaction');
+//     uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
+//     uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
+//     // juniors lost about 10% as there were seniors to cover
+//     assertApproxEqAbs(
+//       preBBPrice * 90000/100000,
+//       postBBPrice, 
+//       200 // 200 wei to account for interest accrued
+//     );
+//     // seniors are covered
+//     assertEq(preAAPrice, postAAPrice, 'AA price unaffected');
+//     assertEq(idleCDO.priceAA(), preAAPrice, 'AA price not updated until new interaction');
+//     assertEq(idleCDO.priceBB(), preBBPrice, 'BB price not updated until new interaction');
 
-    _depositWithUser(idleCDO.rebalancer(), amount, true);
-    _depositWithUser(idleCDO.rebalancer(), amount, false);
+//     _depositWithUser(idleCDO.rebalancer(), amount, true);
+//     _depositWithUser(idleCDO.rebalancer(), amount, false);
 
-    uint256 postDepositAAPrice = idleCDO.virtualPrice(address(AAtranche));
-    uint256 postDepositBBPrice = idleCDO.virtualPrice(address(BBtranche));
+//     uint256 postDepositAAPrice = idleCDO.virtualPrice(address(AAtranche));
+//     uint256 postDepositBBPrice = idleCDO.virtualPrice(address(BBtranche));
 
-    assertEq(postDepositAAPrice, postAAPrice, 'AA price did not change after deposit');
-    assertEq(postDepositBBPrice, postBBPrice, 'BB price did not change after deposit');
-    assertEq(idleCDO.priceAA(), postDepositAAPrice, 'AA saved price updated');
-    assertEq(idleCDO.priceBB(), postDepositBBPrice, 'BB saved price updated');
+//     assertEq(postDepositAAPrice, postAAPrice, 'AA price did not change after deposit');
+//     assertEq(postDepositBBPrice, postBBPrice, 'BB price did not change after deposit');
+//     assertEq(idleCDO.priceAA(), postDepositAAPrice, 'AA saved price updated');
+//     assertEq(idleCDO.priceBB(), postDepositBBPrice, 'BB saved price updated');
 
-    assertEq(idleCDO.unclaimedFees(), unclaimedFees, 'Fees did not increase');
-    vm.clearMockedCalls();
-  }
+//     assertEq(idleCDO.unclaimedFees(), unclaimedFees, 'Fees did not increase');
+//     vm.clearMockedCalls();
+//   }
 
-  function testRedeemWithLossCovered() external {
-    uint256 maxDecrease = IdleCDO(address(idleCDO)).maxDecreaseDefault();
-    uint256 amount = 10000 * ONE_SCALE;
-    // fee is set to 10% and release block period to 0, AARatio 66%
-    (uint256 preAAPrice, uint256 preBBPrice) = _doDepositsWithInterest(amount * 2, amount);
+//   function testRedeemWithLossCovered() external {
+//     uint256 maxDecrease = IdleCDO(address(idleCDO)).maxDecreaseDefault();
+//     uint256 amount = 10000 * ONE_SCALE;
+//     // fee is set to 10% and release block period to 0, AARatio 66%
+//     (uint256 preAAPrice, uint256 preBBPrice) = _doDepositsWithInterest(amount * 2, amount);
 
-    // now let's simulate a loss by decreasing cToken price (so to decrease strategy.price), curr price - 5%
-    vm.mockCall(
-      address(cToken),
-      abi.encodeWithSelector(ICToken.exchangeRateStored.selector),
-      abi.encode(ICToken(cToken).exchangeRateStored() * (FULL_ALLOC - maxDecrease) / FULL_ALLOC)
-    );
+//     // now let's simulate a loss by decreasing cToken price (so to decrease strategy.price), curr price - 5%
+//     vm.mockCall(
+//       address(cToken),
+//       abi.encodeWithSelector(ICToken.exchangeRateStored.selector),
+//       abi.encode(ICToken(cToken).exchangeRateStored() * (FULL_ALLOC - maxDecrease) / FULL_ALLOC)
+//     );
 
-    uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
-    uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
-    // juniors lost about 15% as there were 2x seniors to cover
-    assertApproxEqAbs(
-      postBBPrice, 
-      preBBPrice * 85000/100000,
-      1000, // 1000 wei to account for interest accrued
-      'BB price decreased'
-    );
-    // seniors are covered
-    assertEq(preAAPrice, postAAPrice, 'AA price unaffected');
-    uint256 balPre = underlying.balanceOf(address(this));
-    // we redeem half of the balance to avoid having only feeReceiver as AA holders
-    // otherwise any leftover will easily push AA price up
-    idleCDO.withdrawAA(AAtranche.balanceOf(address(this)) / 2);
-    uint256 balPost = underlying.balanceOf(address(this));
-    assertGt(balPost - balPre, amount, 'AA gained something as loss was totally covered');
+//     uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
+//     uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
+//     // juniors lost about 15% as there were 2x seniors to cover
+//     assertApproxEqAbs(
+//       postBBPrice, 
+//       preBBPrice * 85000/100000,
+//       1000, // 1000 wei to account for interest accrued
+//       'BB price decreased'
+//     );
+//     // seniors are covered
+//     assertEq(preAAPrice, postAAPrice, 'AA price unaffected');
+//     uint256 balPre = underlying.balanceOf(address(this));
+//     // we redeem half of the balance to avoid having only feeReceiver as AA holders
+//     // otherwise any leftover will easily push AA price up
+//     idleCDO.withdrawAA(AAtranche.balanceOf(address(this)) / 2);
+//     uint256 balPost = underlying.balanceOf(address(this));
+//     assertGt(balPost - balPre, amount, 'AA gained something as loss was totally covered');
 
-    // senior v price should be equal to the one before or at most 1 wei greater due to rounding
-    assertApproxEqAbs(
-      idleCDO.virtualPrice(address(AAtranche)), postAAPrice, 1, 
-      'AA price after withdraw did not change or increased'
-    );
-    assertGe(idleCDO.virtualPrice(address(AAtranche)), postAAPrice, 'AA price after withdraw did not change or increased');
-    // junior v price should be unchanged
-    assertEq(idleCDO.virtualPrice(address(BBtranche)), postBBPrice, 'BB price after withdraw did not change');
+//     // senior v price should be equal to the one before or at most 1 wei greater due to rounding
+//     assertApproxEqAbs(
+//       idleCDO.virtualPrice(address(AAtranche)), postAAPrice, 1, 
+//       'AA price after withdraw did not change or increased'
+//     );
+//     assertGe(idleCDO.virtualPrice(address(AAtranche)), postAAPrice, 'AA price after withdraw did not change or increased');
+//     // junior v price should be unchanged
+//     assertEq(idleCDO.virtualPrice(address(BBtranche)), postBBPrice, 'BB price after withdraw did not change');
 
-    // junior lost about 15%
-    idleCDO.withdrawBB(BBtranche.balanceOf(address(this)));
-    uint256 balPostPost = underlying.balanceOf(address(this));
-    assertApproxEqRel(
-      balPostPost - balPost, 
-      amount * 85000/100000, // lost 15% - interest accrued (about 0.2%)
-      3e15, // 0.3% tolerance
-      'BB lost 10% (minus interest accrued)'
-    );
+//     // junior lost about 15%
+//     idleCDO.withdrawBB(BBtranche.balanceOf(address(this)));
+//     uint256 balPostPost = underlying.balanceOf(address(this));
+//     assertApproxEqRel(
+//       balPostPost - balPost, 
+//       amount * 85000/100000, // lost 15% - interest accrued (about 0.2%)
+//       3e15, // 0.3% tolerance
+//       'BB lost 10% (minus interest accrued)'
+//     );
 
-    vm.clearMockedCalls();
-  }
+//     vm.clearMockedCalls();
+//   }
 
-  function testDepositRedeemWithLossShutdown() external {
-    uint256 amount = 10000 * ONE_SCALE;
-    // fee is set to 10% and release block period to 0
+//   function testDepositRedeemWithLossShutdown() external {
+//     uint256 amount = 10000 * ONE_SCALE;
+//     // fee is set to 10% and release block period to 0
 
-    // AA Ratio 98%
-    (uint256 preAAPrice, uint256 preBBPrice) = _doDepositsWithInterest(amount - amount / 50, amount / 50);
+//     // AA Ratio 98%
+//     (uint256 preAAPrice, uint256 preBBPrice) = _doDepositsWithInterest(amount - amount / 50, amount / 50);
 
-    uint256 currPrice = strategy.price();
-    uint256 maxDecrease = IdleCDO(address(idleCDO)).maxDecreaseDefault();
-    uint256 unclaimedFees = idleCDO.unclaimedFees();
-    // now let's simulate a loss by decreasing strategy price
-    // curr price - 5%, this will trigger a default because the loss is >= junior tvl
-    vm.mockCall(
-      address(strategy),
-      abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
-      abi.encode(currPrice * (FULL_ALLOC - maxDecrease) / FULL_ALLOC)
-    );
+//     uint256 currPrice = strategy.price();
+//     uint256 maxDecrease = IdleCDO(address(idleCDO)).maxDecreaseDefault();
+//     uint256 unclaimedFees = idleCDO.unclaimedFees();
+//     // now let's simulate a loss by decreasing strategy price
+//     // curr price - 5%, this will trigger a default because the loss is >= junior tvl
+//     vm.mockCall(
+//       address(strategy),
+//       abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
+//       abi.encode(currPrice * (FULL_ALLOC - maxDecrease) / FULL_ALLOC)
+//     );
 
-    uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
-    uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
-    // juniors lost 100% as they need to cover seniors
-    assertEq(0, postBBPrice, 'Full loss for junior tranche');
-    // seniors are covered
-    assertApproxEqAbs(
-      preAAPrice * 97000/100000,
-      postAAPrice, 
-      1000, // 1000 wei to account for interest accrued
-      'AA price lost about 3% (2% covered by junior)'
-    );
-    assertEq(idleCDO.priceAA(), preAAPrice, 'AA price not updated until new interaction');
-    assertEq(idleCDO.priceBB(), preBBPrice, 'BB price not updated until new interaction');
+//     uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
+//     uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
+//     // juniors lost 100% as they need to cover seniors
+//     assertEq(0, postBBPrice, 'Full loss for junior tranche');
+//     // seniors are covered
+//     assertApproxEqAbs(
+//       preAAPrice * 97000/100000,
+//       postAAPrice, 
+//       1000, // 1000 wei to account for interest accrued
+//       'AA price lost about 3% (2% covered by junior)'
+//     );
+//     assertEq(idleCDO.priceAA(), preAAPrice, 'AA price not updated until new interaction');
+//     assertEq(idleCDO.priceBB(), preBBPrice, 'BB price not updated until new interaction');
 
-    address newUser = address(123456);
-    deal(address(underlying), newUser, amount * 2);
-    // do another interaction to effectively update prices and trigger default
-    vm.startPrank(newUser);
-    // both deposits will revert as loss will accrue and leave 0 to juniors
-    underlying.approve(address(idleCDO), amount * 2);
-    vm.expectRevert(bytes("4"));
-    idleCDO.depositAA(amount);
-    vm.expectRevert(bytes("4"));
-    idleCDO.depositBB(amount);
-    vm.expectRevert(bytes("4"));
-    idleCDO.withdrawAA(amount);
-    vm.expectRevert(bytes("4"));
-    idleCDO.withdrawBB(amount);
-    vm.stopPrank();
+//     address newUser = address(123456);
+//     deal(address(underlying), newUser, amount * 2);
+//     // do another interaction to effectively update prices and trigger default
+//     vm.startPrank(newUser);
+//     // both deposits will revert as loss will accrue and leave 0 to juniors
+//     underlying.approve(address(idleCDO), amount * 2);
+//     vm.expectRevert(bytes("4"));
+//     idleCDO.depositAA(amount);
+//     vm.expectRevert(bytes("4"));
+//     idleCDO.depositBB(amount);
+//     vm.expectRevert(bytes("4"));
+//     idleCDO.withdrawAA(amount);
+//     vm.expectRevert(bytes("4"));
+//     idleCDO.withdrawBB(amount);
+//     vm.stopPrank();
 
-    vm.prank(idleCDO.owner());
-    IdleCDO(address(idleCDO)).updateAccounting();
-    // loss is now distributed and shutdown triggered
+//     vm.prank(idleCDO.owner());
+//     IdleCDO(address(idleCDO)).updateAccounting();
+//     // loss is now distributed and shutdown triggered
 
-    uint256 postDepositAAPrice = idleCDO.virtualPrice(address(AAtranche));
-    uint256 postDepositBBPrice = idleCDO.virtualPrice(address(BBtranche));
+//     uint256 postDepositAAPrice = idleCDO.virtualPrice(address(AAtranche));
+//     uint256 postDepositBBPrice = idleCDO.virtualPrice(address(BBtranche));
 
-    assertEq(postDepositAAPrice, postAAPrice, 'AA price did not change after deposit');
-    assertEq(postDepositBBPrice, postBBPrice, 'BB price did not change after deposit');
-    assertEq(idleCDO.priceAA(), postDepositAAPrice, 'AA saved price updated');
-    assertEq(idleCDO.priceBB(), postDepositBBPrice, 'BB saved price updated');
-    assertEq(idleCDO.unclaimedFees(), unclaimedFees, 'Fees did not increase');
-    assertEq(idleCDO.allowAAWithdraw(), false, 'Default flag for senior set');
-    assertEq(idleCDO.allowBBWithdraw(), false, 'Default flag for senior set');
-    assertEq(idleCDO.lastNAVBB(), 0, 'Last junior TVL should be 0');
+//     assertEq(postDepositAAPrice, postAAPrice, 'AA price did not change after deposit');
+//     assertEq(postDepositBBPrice, postBBPrice, 'BB price did not change after deposit');
+//     assertEq(idleCDO.priceAA(), postDepositAAPrice, 'AA saved price updated');
+//     assertEq(idleCDO.priceBB(), postDepositBBPrice, 'BB saved price updated');
+//     assertEq(idleCDO.unclaimedFees(), unclaimedFees, 'Fees did not increase');
+//     assertEq(idleCDO.allowAAWithdraw(), false, 'Default flag for senior set');
+//     assertEq(idleCDO.allowBBWithdraw(), false, 'Default flag for senior set');
+//     assertEq(idleCDO.lastNAVBB(), 0, 'Last junior TVL should be 0');
 
-    // deposits/redeems are disabled
-    vm.expectRevert(bytes("Pausable: paused"));
-    idleCDO.depositAA(amount);
-    vm.expectRevert(bytes("Pausable: paused"));
-    idleCDO.depositBB(amount);
-    vm.expectRevert(bytes("3"));
-    idleCDO.withdrawAA(amount);
-    vm.expectRevert(bytes("3"));
-    idleCDO.withdrawBB(amount);
+//     // deposits/redeems are disabled
+//     vm.expectRevert(bytes("Pausable: paused"));
+//     idleCDO.depositAA(amount);
+//     vm.expectRevert(bytes("Pausable: paused"));
+//     idleCDO.depositBB(amount);
+//     vm.expectRevert(bytes("3"));
+//     idleCDO.withdrawAA(amount);
+//     vm.expectRevert(bytes("3"));
+//     idleCDO.withdrawBB(amount);
 
-    vm.clearMockedCalls();
-  }
+//     vm.clearMockedCalls();
+//   }
 
-  function testCheckMaxDecreaseDefault() external {
-    uint256 amount = 10000 * ONE_SCALE;
-    // fee is set to 10% and release block period to 0
+//   function testCheckMaxDecreaseDefault() external {
+//     uint256 amount = 10000 * ONE_SCALE;
+//     // fee is set to 10% and release block period to 0
 
-    // AA Ratio 98%
-    (uint256 preAAPrice, ) = _doDepositsWithInterest(amount - amount / 50, amount / 50);
+//     // AA Ratio 98%
+//     (uint256 preAAPrice, ) = _doDepositsWithInterest(amount - amount / 50, amount / 50);
 
-    uint256 currPrice = strategy.price();
-    uint256 maxDecrease = IdleCDO(address(idleCDO)).maxDecreaseDefault();
-    // now let's simulate a loss by decreasing strategy price
-    // curr price - 10%, this will trigger a default
-    vm.mockCall(
-      address(strategy),
-      abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
-      abi.encode(currPrice * (FULL_ALLOC - maxDecrease * 2) / FULL_ALLOC)
-    );
+//     uint256 currPrice = strategy.price();
+//     uint256 maxDecrease = IdleCDO(address(idleCDO)).maxDecreaseDefault();
+//     // now let's simulate a loss by decreasing strategy price
+//     // curr price - 10%, this will trigger a default
+//     vm.mockCall(
+//       address(strategy),
+//       abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
+//       abi.encode(currPrice * (FULL_ALLOC - maxDecrease * 2) / FULL_ALLOC)
+//     );
 
-    uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
-    uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
-    // juniors lost 100% as they need to cover seniors
-    assertEq(0, postBBPrice, 'Full loss for junior tranche');
-    // seniors are covered
-    assertApproxEqAbs(
-      preAAPrice * 92000/100000,
-      postAAPrice, 
-      2000, // 2000 wei to account for interest accrued
-      'AA price lost about 8% (2% covered by junior)'
-    );
+//     uint256 postAAPrice = idleCDO.virtualPrice(address(AAtranche));
+//     uint256 postBBPrice = idleCDO.virtualPrice(address(BBtranche));
+//     // juniors lost 100% as they need to cover seniors
+//     assertEq(0, postBBPrice, 'Full loss for junior tranche');
+//     // seniors are covered
+//     assertApproxEqAbs(
+//       preAAPrice * 92000/100000,
+//       postAAPrice, 
+//       2000, // 2000 wei to account for interest accrued
+//       'AA price lost about 8% (2% covered by junior)'
+//     );
 
-    // deposits/redeems are disabled
-    vm.expectRevert(bytes("4"));
-    idleCDO.depositAA(amount);
-    vm.expectRevert(bytes("4"));
-    idleCDO.depositBB(amount);
-    vm.expectRevert(bytes("4"));
-    idleCDO.withdrawAA(amount);
-    vm.expectRevert(bytes("4"));
-    idleCDO.withdrawBB(amount);
+//     // deposits/redeems are disabled
+//     vm.expectRevert(bytes("4"));
+//     idleCDO.depositAA(amount);
+//     vm.expectRevert(bytes("4"));
+//     idleCDO.depositBB(amount);
+//     vm.expectRevert(bytes("4"));
+//     idleCDO.withdrawAA(amount);
+//     vm.expectRevert(bytes("4"));
+//     idleCDO.withdrawBB(amount);
 
-    // distribute loss, as non owner
-    vm.startPrank(address(232323));
-    vm.expectRevert(bytes("6"));
-    IdleCDO(address(idleCDO)).updateAccounting();
-    vm.stopPrank();
+//     // distribute loss, as non owner
+//     vm.startPrank(address(232323));
+//     vm.expectRevert(bytes("6"));
+//     IdleCDO(address(idleCDO)).updateAccounting();
+//     vm.stopPrank();
   
-    // effectively distribute loss
-    vm.prank(idleCDO.owner());
-    IdleCDO(address(idleCDO)).updateAccounting();
+//     // effectively distribute loss
+//     vm.prank(idleCDO.owner());
+//     IdleCDO(address(idleCDO)).updateAccounting();
 
-    assertEq(idleCDO.priceAA(), postAAPrice, 'AA saved price updated');
-    assertEq(idleCDO.priceBB(), 0, 'BB saved price updated');
+//     assertEq(idleCDO.priceAA(), postAAPrice, 'AA saved price updated');
+//     assertEq(idleCDO.priceBB(), 0, 'BB saved price updated');
 
-    vm.clearMockedCalls();
-  }
+//     vm.clearMockedCalls();
+//   }
 
-  function _depositWithUser(address _user, uint256 _amount, bool _isAA) internal {
-    deal(address(underlying), _user, _amount * 2);
-    // do another interaction to effectively update prices
-    vm.startPrank(_user);
-    underlying.safeIncreaseAllowance(address(idleCDO), _amount);
-    if (_isAA) {
-      idleCDO.depositAA(_amount);
-    } else {
-      idleCDO.depositBB(_amount);
-    }
-    vm.stopPrank();
-    vm.roll(block.number + 1);
-  }
+//   function _depositWithUser(address _user, uint256 _amount, bool _isAA) internal {
+//     deal(address(underlying), _user, _amount * 2);
+//     // do another interaction to effectively update prices
+//     vm.startPrank(_user);
+//     underlying.safeIncreaseAllowance(address(idleCDO), _amount);
+//     if (_isAA) {
+//       idleCDO.depositAA(_amount);
+//     } else {
+//       idleCDO.depositBB(_amount);
+//     }
+//     vm.stopPrank();
+//     vm.roll(block.number + 1);
+//   }
 
-  function _doDepositsWithInterest(uint256 aa, uint256 bb) 
-    internal 
-    returns (uint256 priceAA, uint256 priceBB) {
-    vm.startPrank(owner);
-    idleCDO.setReleaseBlocksPeriod(0);
-    idleCDO.setFee(10000);
-    vm.stopPrank();
+//   function _doDepositsWithInterest(uint256 aa, uint256 bb) 
+//     internal 
+//     returns (uint256 priceAA, uint256 priceBB) {
+//     vm.startPrank(owner);
+//     idleCDO.setReleaseBlocksPeriod(0);
+//     idleCDO.setFee(10000);
+//     vm.stopPrank();
 
-    idleCDO.depositAA(aa);
-    idleCDO.depositBB(bb);
+//     idleCDO.depositAA(aa);
+//     idleCDO.depositBB(bb);
 
-    // deposit underlyings to the strategy
-    _cdoHarvest(true);
-    // accrue some interest 
-    skip(30 days);
-    vm.roll(block.number + 30 * 7200); // 7 days in blocks, needed for compound
-    // claim and sell rewards
-    _cdoHarvest(false);
-    vm.roll(block.number + 1); // 7 days in blocks
+//     // deposit underlyings to the strategy
+//     _cdoHarvest(true);
+//     // accrue some interest 
+//     skip(30 days);
+//     vm.roll(block.number + 30 * 7200); // 7 days in blocks, needed for compound
+//     // claim and sell rewards
+//     _cdoHarvest(false);
+//     vm.roll(block.number + 1); // 7 days in blocks
 
-    priceAA = idleCDO.virtualPrice(address(AAtranche));
-    priceBB = idleCDO.virtualPrice(address(BBtranche));
-    assertGt(priceAA, ONE_SCALE, 'AA price is > 1');
-    assertGt(priceBB, ONE_SCALE, 'BB price is > 1');
-  }
-}
+//     priceAA = idleCDO.virtualPrice(address(AAtranche));
+//     priceBB = idleCDO.virtualPrice(address(BBtranche));
+//     assertGt(priceAA, ONE_SCALE, 'AA price is > 1');
+//     assertGt(priceBB, ONE_SCALE, 'BB price is > 1');
+//   }
+// }

--- a/test/foundry/IdleLeveragedEulerStrategy.t.sol
+++ b/test/foundry/IdleLeveragedEulerStrategy.t.sol
@@ -1,626 +1,626 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.10;
+// // SPDX-License-Identifier: MIT
+// pragma solidity 0.8.10;
 
-import "../../contracts/strategies/euler/IdleLeveragedEulerStrategy.sol";
+// import "../../contracts/strategies/euler/IdleLeveragedEulerStrategy.sol";
 
-import "forge-std/Test.sol";
+// import "forge-std/Test.sol";
 
-import "./TestIdleCDOBase.sol";
-import "../../contracts/IdleCDOLeveregedEulerVariant.sol";
+// import "./TestIdleCDOBase.sol";
+// import "../../contracts/IdleCDOLeveregedEulerVariant.sol";
 
-contract TestIdleEulerLeveragedStrategy is TestIdleCDOBase {
-    using stdStorage for StdStorage;
+// contract TestIdleEulerLeveragedStrategy is TestIdleCDOBase {
+//     using stdStorage for StdStorage;
 
-    uint256 internal constant EXP_SCALE = 1e18;
+//     uint256 internal constant EXP_SCALE = 1e18;
 
-    uint256 internal constant ONE_FACTOR_SCALE = 1_000_000_000;
+//     uint256 internal constant ONE_FACTOR_SCALE = 1_000_000_000;
 
-    uint256 internal constant CONFIG_FACTOR_SCALE = 4_000_000_000;
+//     uint256 internal constant CONFIG_FACTOR_SCALE = 4_000_000_000;
 
-    uint256 internal constant SELF_COLLATERAL_FACTOR = 0.95 * 4_000_000_000;
+//     uint256 internal constant SELF_COLLATERAL_FACTOR = 0.95 * 4_000_000_000;
 
-    /// @notice Euler markets contract address
-    IMarkets internal constant EULER_MARKETS = IMarkets(0x3520d5a913427E6F0D6A83E07ccD4A4da316e4d3);
+//     /// @notice Euler markets contract address
+//     IMarkets internal constant EULER_MARKETS = IMarkets(0x3520d5a913427E6F0D6A83E07ccD4A4da316e4d3);
 
-    /// @notice Euler general view contract address
-    IEulerGeneralView internal constant EULER_GENERAL_VIEW =
-        IEulerGeneralView(0xACC25c4d40651676FEEd43a3467F3169e3E68e42);
+//     /// @notice Euler general view contract address
+//     IEulerGeneralView internal constant EULER_GENERAL_VIEW =
+//         IEulerGeneralView(0xACC25c4d40651676FEEd43a3467F3169e3E68e42);
 
-    IExec internal constant EULER_EXEC = IExec(0x59828FdF7ee634AaaD3f58B19fDBa3b03E2D9d80);
+//     IExec internal constant EULER_EXEC = IExec(0x59828FdF7ee634AaaD3f58B19fDBa3b03E2D9d80);
 
-    address internal constant EUL = 0xd9Fcd98c322942075A5C3860693e9f4f03AAE07b;
-    address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+//     address internal constant EUL = 0xd9Fcd98c322942075A5C3860693e9f4f03AAE07b;
+//     address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
 
-    address internal constant WETH9 = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+//     address internal constant WETH9 = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
-    uint256 internal constant INITIAL_TARGET_HEALTH = 1.2 * 1e18;
+//     uint256 internal constant INITIAL_TARGET_HEALTH = 1.2 * 1e18;
 
-    ISwapRouter internal router = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
+//     ISwapRouter internal router = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
 
-    IEulDistributor public eulDistributor;
+//     IEulDistributor public eulDistributor;
 
-    address internal eulerMain;
+//     address internal eulerMain;
 
-    IEToken internal eToken;
+//     IEToken internal eToken;
 
-    IDToken internal dToken;
+//     IDToken internal dToken;
 
-    bytes internal path;
+//     bytes internal path;
 
-    function _updateClaimable(uint256 _new) internal {
-        extraData = abi.encode(uint256(_new), new bytes32[](0), uint256(0));
-    }
+//     function _updateClaimable(uint256 _new) internal {
+//         extraData = abi.encode(uint256(_new), new bytes32[](0), uint256(0));
+//     }
 
-    function _deployStrategy(address _owner) internal override returns (address _strategy, address _underlying) {
-        eulerMain = 0x27182842E098f60e3D576794A5bFFb0777E025d3;
-        eToken = IEToken(0xEb91861f8A4e1C12333F42DCE8fB0Ecdc28dA716); // eUSDC
-        dToken = IDToken(0x84721A3dB22EB852233AEAE74f9bC8477F8bcc42); // dUSDC
-        bytes[] memory _extraPath = new bytes[](1);
-        _extraPath[0] = abi.encodePacked(EUL, uint24(10000), USDC);
-        extraDataSell = abi.encode(_extraPath);
-        _underlying = USDC;
+//     function _deployStrategy(address _owner) internal override returns (address _strategy, address _underlying) {
+//         eulerMain = 0x27182842E098f60e3D576794A5bFFb0777E025d3;
+//         eToken = IEToken(0xEb91861f8A4e1C12333F42DCE8fB0Ecdc28dA716); // eUSDC
+//         dToken = IDToken(0x84721A3dB22EB852233AEAE74f9bC8477F8bcc42); // dUSDC
+//         bytes[] memory _extraPath = new bytes[](1);
+//         _extraPath[0] = abi.encodePacked(EUL, uint24(10000), USDC);
+//         extraDataSell = abi.encode(_extraPath);
+//         _underlying = USDC;
 
-        strategy = new IdleLeveragedEulerStrategy();
-        _strategy = address(strategy);
+//         strategy = new IdleLeveragedEulerStrategy();
+//         _strategy = address(strategy);
 
-        eulDistributor = new EulDistributorMock();
-        deal(EUL, address(eulDistributor), 1e23, true);
-        deal(_underlying, address(1), 1e23, true);
-        deal(_underlying, address(2), 1e23, true);
+//         eulDistributor = new EulDistributorMock();
+//         deal(EUL, address(eulDistributor), 1e23, true);
+//         deal(_underlying, address(1), 1e23, true);
+//         deal(_underlying, address(2), 1e23, true);
 
-        // claim data
-        _updateClaimable(1000e18);
-        extraRewards = 1;
-        // v3 router path
-        path = abi.encodePacked(EUL, uint24(10000), WETH9, uint24(3000), _underlying);
-        stdstore.target(_strategy).sig(strategy.token.selector).checked_write(address(0));
-        IdleLeveragedEulerStrategy(_strategy).initialize(
-            eulerMain,
-            address(eToken),
-            address(dToken),
-            _underlying,
-            _owner,
-            address(eulDistributor),
-            address(router),
-            path,
-            INITIAL_TARGET_HEALTH
-        );
+//         // claim data
+//         _updateClaimable(1000e18);
+//         extraRewards = 1;
+//         // v3 router path
+//         path = abi.encodePacked(EUL, uint24(10000), WETH9, uint24(3000), _underlying);
+//         stdstore.target(_strategy).sig(strategy.token.selector).checked_write(address(0));
+//         IdleLeveragedEulerStrategy(_strategy).initialize(
+//             eulerMain,
+//             address(eToken),
+//             address(dToken),
+//             _underlying,
+//             _owner,
+//             address(eulDistributor),
+//             address(router),
+//             path,
+//             INITIAL_TARGET_HEALTH
+//         );
 
-        vm.label(eulerMain, "euler");
-        vm.label(address(eToken), "eToken");
-        vm.label(address(dToken), "dToken");
-        vm.label(WETH9, "WETH9");
-        vm.label(address(eulDistributor), "eulDist");
-        vm.label(address(router), "router");
-    }
+//         vm.label(eulerMain, "euler");
+//         vm.label(address(eToken), "eToken");
+//         vm.label(address(dToken), "dToken");
+//         vm.label(WETH9, "WETH9");
+//         vm.label(address(eulDistributor), "eulDist");
+//         vm.label(address(router), "router");
+//     }
 
-    function _deployCDO() internal override returns (IdleCDO _cdo) {
-        _cdo = new IdleCDOLeveregedEulerVariant();
-    }
+//     function _deployCDO() internal override returns (IdleCDO _cdo) {
+//         _cdo = new IdleCDOLeveregedEulerVariant();
+//     }
 
-    function _postDeploy(address _cdo, address _owner) internal override {
-        vm.startPrank(_owner);
-        IdleLeveragedEulerStrategy(address(strategy)).setWhitelistedCDO(_cdo);
-        IdleCDOLeveregedEulerVariant(_cdo).setMaxDecreaseDefault(1000); // 1%
-        vm.stopPrank();
+//     function _postDeploy(address _cdo, address _owner) internal override {
+//         vm.startPrank(_owner);
+//         IdleLeveragedEulerStrategy(address(strategy)).setWhitelistedCDO(_cdo);
+//         IdleCDOLeveregedEulerVariant(_cdo).setMaxDecreaseDefault(1000); // 1%
+//         vm.stopPrank();
 
-        vm.prank(address(1));
-        IERC20Detailed(USDC).approve(_cdo, type(uint256).max);
-        vm.prank(address(2));
-        IERC20Detailed(USDC).approve(_cdo, type(uint256).max);
-    }
+//         vm.prank(address(1));
+//         IERC20Detailed(USDC).approve(_cdo, type(uint256).max);
+//         vm.prank(address(2));
+//         IERC20Detailed(USDC).approve(_cdo, type(uint256).max);
+//     }
 
-    function testMultipleRedeemsWithRewards() external runOnForkingNetwork(MAINNET_CHIANID) {
-        uint256 amount = 10000 * ONE_SCALE;
-        uint256 balBefore = underlying.balanceOf(address(this));
-        uint256 balBefor1 = underlying.balanceOf(address(1));
-        idleCDO.depositAA(amount);
-        idleCDO.depositBB(amount);
-        uint256 aaBal = IERC20Detailed(address(AAtranche)).balanceOf(address(this));
-        uint256 bbBal = IERC20Detailed(address(BBtranche)).balanceOf(address(this));
-        uint256 pricePre = strategy.price();
-        // funds in lending
-        _cdoHarvest(true, true);
-        // accrue some loss
-        skip(7 days);
-        vm.roll(block.number + _strategyReleaseBlocksPeriod() / 2);
+//     function testMultipleRedeemsWithRewards() external runOnForkingNetwork(MAINNET_CHIANID) {
+//         uint256 amount = 10000 * ONE_SCALE;
+//         uint256 balBefore = underlying.balanceOf(address(this));
+//         uint256 balBefor1 = underlying.balanceOf(address(1));
+//         idleCDO.depositAA(amount);
+//         idleCDO.depositBB(amount);
+//         uint256 aaBal = IERC20Detailed(address(AAtranche)).balanceOf(address(this));
+//         uint256 bbBal = IERC20Detailed(address(BBtranche)).balanceOf(address(this));
+//         uint256 pricePre = strategy.price();
+//         // funds in lending
+//         _cdoHarvest(true, true);
+//         // accrue some loss
+//         skip(7 days);
+//         vm.roll(block.number + _strategyReleaseBlocksPeriod() / 2);
         
-        uint256 pricePost = strategy.price();
-        // here we didn't harvested any rewards and 
-        // borrow apy > supply apr so the strategy price decreases
-        assertLt(pricePost, pricePre, 'Strategy price did not decrease, loss not reported');
+//         uint256 pricePost = strategy.price();
+//         // here we didn't harvested any rewards and 
+//         // borrow apy > supply apr so the strategy price decreases
+//         assertLt(pricePost, pricePre, 'Strategy price did not decrease, loss not reported');
         
-        // deposit with another user, price for mint is still oneToken
-        vm.startPrank(address(1));
-        idleCDO.depositAA(amount);
-        idleCDO.depositBB(amount);
-        vm.stopPrank();
-        // put new fund in lending
-        _cdoHarvest(true, true);
+//         // deposit with another user, price for mint is still oneToken
+//         vm.startPrank(address(1));
+//         idleCDO.depositAA(amount);
+//         idleCDO.depositBB(amount);
+//         vm.stopPrank();
+//         // put new fund in lending
+//         _cdoHarvest(true, true);
 
-        uint256 aaBal1 = IERC20Detailed(address(AAtranche)).balanceOf(address(1));
-        uint256 bbBal1 = IERC20Detailed(address(BBtranche)).balanceOf(address(1));
-        assertEq(aaBal1, aaBal, 'AA balance minted is != than before');
-        assertEq(bbBal1, bbBal, 'BB balance minted is != than before');
-        // accrue some more loss
-        skip(7 days);
-        vm.roll(block.number + _strategyReleaseBlocksPeriod() / 2);
+//         uint256 aaBal1 = IERC20Detailed(address(AAtranche)).balanceOf(address(1));
+//         uint256 bbBal1 = IERC20Detailed(address(BBtranche)).balanceOf(address(1));
+//         assertEq(aaBal1, aaBal, 'AA balance minted is != than before');
+//         assertEq(bbBal1, bbBal, 'BB balance minted is != than before');
+//         // accrue some more loss
+//         skip(7 days);
+//         vm.roll(block.number + _strategyReleaseBlocksPeriod() / 2);
 
-        // claim accrued euler tokens but do not release rewards
-        _cdoHarvest(false, true);
+//         // claim accrued euler tokens but do not release rewards
+//         _cdoHarvest(false, true);
 
-        skip(7 days);
-        // release half rewards
-        vm.roll(block.number + _strategyReleaseBlocksPeriod() / 2);
+//         skip(7 days);
+//         // release half rewards
+//         vm.roll(block.number + _strategyReleaseBlocksPeriod() / 2);
 
-        vm.startPrank(address(1));
-        idleCDO.withdrawAA(aaBal1);
-        idleCDO.withdrawBB(bbBal1);
-        vm.stopPrank();
+//         vm.startPrank(address(1));
+//         idleCDO.withdrawAA(aaBal1);
+//         idleCDO.withdrawBB(bbBal1);
+//         vm.stopPrank();
 
-        idleCDO.withdrawAA(aaBal);
-        idleCDO.withdrawBB(bbBal);
+//         idleCDO.withdrawAA(aaBal);
+//         idleCDO.withdrawBB(bbBal);
 
-        uint256 balAfter = underlying.balanceOf(address(this));
-        uint256 balAfter1 = underlying.balanceOf(address(1));
-        assertLt(balBefore, balAfter, 'underlying balance for address(this) is < than before');
-        assertLt(balBefor1, balAfter1, 'underlying balance for address(1) is < than before');
-        uint256 increaseThis = balAfter - balBefore;
-        uint256 increase1 = balAfter1 - balBefor1;
-        assertGe(increaseThis, increase1, "gain for address this is < than gain of addr(1)");
-    }
+//         uint256 balAfter = underlying.balanceOf(address(this));
+//         uint256 balAfter1 = underlying.balanceOf(address(1));
+//         assertLt(balBefore, balAfter, 'underlying balance for address(this) is < than before');
+//         assertLt(balBefor1, balAfter1, 'underlying balance for address(1) is < than before');
+//         uint256 increaseThis = balAfter - balBefore;
+//         uint256 increase1 = balAfter1 - balBefor1;
+//         assertGe(increaseThis, increase1, "gain for address this is < than gain of addr(1)");
+//     }
 
-    function testLeverageManually() external runOnForkingNetwork(MAINNET_CHIANID) {
-        // set targetHealthScore
-        vm.prank(owner);
-        IdleLeveragedEulerStrategy(address(strategy)).setTargetHealthScore(0); // no lev
+//     function testLeverageManually() external runOnForkingNetwork(MAINNET_CHIANID) {
+//         // set targetHealthScore
+//         vm.prank(owner);
+//         IdleLeveragedEulerStrategy(address(strategy)).setTargetHealthScore(0); // no lev
 
-        uint256 amount = 10000 * ONE_SCALE;
-        idleCDO.depositAA(amount);
-        // funds in lending
-        _cdoHarvest(true, true);
-        assertEq(_getCurrentLeverage(), 0, 'Not levereged');
-        assertEq(dToken.balanceOf(address(strategy)), 0, 'Current strategy has no debt');
+//         uint256 amount = 10000 * ONE_SCALE;
+//         idleCDO.depositAA(amount);
+//         // funds in lending
+//         _cdoHarvest(true, true);
+//         assertEq(_getCurrentLeverage(), 0, 'Not levereged');
+//         assertEq(dToken.balanceOf(address(strategy)), 0, 'Current strategy has no debt');
 
-        uint256 targetHealth = 110 * EXP_SCALE / 100;
-        vm.prank(owner);
-        // deleverege all and set target health to special value 0 ie no leverage
-        IdleLeveragedEulerStrategy(address(strategy)).leverageManually(targetHealth);
+//         uint256 targetHealth = 110 * EXP_SCALE / 100;
+//         vm.prank(owner);
+//         // deleverege all and set target health to special value 0 ie no leverage
+//         IdleLeveragedEulerStrategy(address(strategy)).leverageManually(targetHealth);
 
-        assertApproxEqRel(
-            _getCurrentLeverage(),
-            6 * ONE_SCALE,
-            2e16, // 0.2
-            'Current target health does not match expected one'
-        );
-        assertApproxEqRel(
-            _getCurrentHealthScore(),
-            targetHealth,
-            1e15, // 0.1%
-            'Current target health does not match expected one'
-        );
-        assertGt(dToken.balanceOf(address(strategy)), 0, 'Current strategy has debt');
+//         assertApproxEqRel(
+//             _getCurrentLeverage(),
+//             6 * ONE_SCALE,
+//             2e16, // 0.2
+//             'Current target health does not match expected one'
+//         );
+//         assertApproxEqRel(
+//             _getCurrentHealthScore(),
+//             targetHealth,
+//             1e15, // 0.1%
+//             'Current target health does not match expected one'
+//         );
+//         assertGt(dToken.balanceOf(address(strategy)), 0, 'Current strategy has debt');
 
-        idleCDO.depositAA(amount);
+//         idleCDO.depositAA(amount);
 
-        assertApproxEqRel(
-            _getCurrentLeverage(),
-            6 * ONE_SCALE,
-            2e16, // 0.2
-            'Current target health does not match expected one after deposit'
-        );
-        assertApproxEqRel(
-            _getCurrentHealthScore(),
-            targetHealth,
-            1e15, // 0.1%
-            'Current target health does not match expected one after deposit'
-        );
-        assertGt(dToken.balanceOf(address(strategy)), 0, 'Current strategy has debt after another deposit');
-    }
+//         assertApproxEqRel(
+//             _getCurrentLeverage(),
+//             6 * ONE_SCALE,
+//             2e16, // 0.2
+//             'Current target health does not match expected one after deposit'
+//         );
+//         assertApproxEqRel(
+//             _getCurrentHealthScore(),
+//             targetHealth,
+//             1e15, // 0.1%
+//             'Current target health does not match expected one after deposit'
+//         );
+//         assertGt(dToken.balanceOf(address(strategy)), 0, 'Current strategy has debt after another deposit');
+//     }
 
-    function testDeleverageAllManually() external runOnForkingNetwork(MAINNET_CHIANID) {
-        // set targetHealthScore
-        vm.prank(owner);
-        IdleLeveragedEulerStrategy(address(strategy)).setTargetHealthScore(105 * EXP_SCALE / 100); // 1.05
+//     function testDeleverageAllManually() external runOnForkingNetwork(MAINNET_CHIANID) {
+//         // set targetHealthScore
+//         vm.prank(owner);
+//         IdleLeveragedEulerStrategy(address(strategy)).setTargetHealthScore(105 * EXP_SCALE / 100); // 1.05
 
-        uint256 amount = 10000 * ONE_SCALE;
-        idleCDO.depositAA(amount);
-        // funds in lending
-        _cdoHarvest(true, true);
-        assertGt(_getCurrentLeverage(), ONE_SCALE, 'Not levereged');
-        assertGt(dToken.balanceOf(address(strategy)), 0, 'Current strategy has no debt');
+//         uint256 amount = 10000 * ONE_SCALE;
+//         idleCDO.depositAA(amount);
+//         // funds in lending
+//         _cdoHarvest(true, true);
+//         assertGt(_getCurrentLeverage(), ONE_SCALE, 'Not levereged');
+//         assertGt(dToken.balanceOf(address(strategy)), 0, 'Current strategy has no debt');
 
-        vm.prank(owner);
-        // deleverege all and set target health to special value 0 ie no leverage
-        IdleLeveragedEulerStrategy(address(strategy)).deleverageManually(0);
+//         vm.prank(owner);
+//         // deleverege all and set target health to special value 0 ie no leverage
+//         IdleLeveragedEulerStrategy(address(strategy)).deleverageManually(0);
 
-        assertEq(_getCurrentLeverage(), 0, 'Still levereged');
-        assertEq(_getCurrentHealthScore(), 0, 'Current target health is not 0');
-        assertEq(dToken.balanceOf(address(strategy)), 0, 'Current strategy has debt');
+//         assertEq(_getCurrentLeverage(), 0, 'Still levereged');
+//         assertEq(_getCurrentHealthScore(), 0, 'Current target health is not 0');
+//         assertEq(dToken.balanceOf(address(strategy)), 0, 'Current strategy has debt');
 
-        idleCDO.depositAA(amount);
+//         idleCDO.depositAA(amount);
 
-        assertEq(_getCurrentLeverage(), 0, 'Still levereged');
-        assertEq(_getCurrentHealthScore(), 0, 'Current target health is not 0 after another deposit');
-        assertEq(dToken.balanceOf(address(strategy)), 0, 'Current strategy has debt after another deposit');
-    }
+//         assertEq(_getCurrentLeverage(), 0, 'Still levereged');
+//         assertEq(_getCurrentHealthScore(), 0, 'Current target health is not 0 after another deposit');
+//         assertEq(dToken.balanceOf(address(strategy)), 0, 'Current strategy has debt after another deposit');
+//     }
 
-    function testDeleverageManually() external runOnForkingNetwork(MAINNET_CHIANID) {
-        // set targetHealthScore
-        vm.prank(owner);
-        IdleLeveragedEulerStrategy(address(strategy)).setTargetHealthScore(105 * EXP_SCALE / 100); // 1.05
+//     function testDeleverageManually() external runOnForkingNetwork(MAINNET_CHIANID) {
+//         // set targetHealthScore
+//         vm.prank(owner);
+//         IdleLeveragedEulerStrategy(address(strategy)).setTargetHealthScore(105 * EXP_SCALE / 100); // 1.05
 
-        uint256 amount = 10000 * ONE_SCALE;
-        idleCDO.depositAA(amount);
-        // funds in lending
-        _cdoHarvest(true, true);
-        uint256 initialLev = _getCurrentLeverage();
-        assertGt(initialLev, ONE_SCALE, 'Not levereged');
-        assertGt(dToken.balanceOf(address(strategy)), 0, 'Current strategy has no debt');
+//         uint256 amount = 10000 * ONE_SCALE;
+//         idleCDO.depositAA(amount);
+//         // funds in lending
+//         _cdoHarvest(true, true);
+//         uint256 initialLev = _getCurrentLeverage();
+//         assertGt(initialLev, ONE_SCALE, 'Not levereged');
+//         assertGt(dToken.balanceOf(address(strategy)), 0, 'Current strategy has no debt');
 
-        uint256 _targetHealthScore = 2 * EXP_SCALE; // 1.1
-        // uint256 _targetHealthScore = 110 * EXP_SCALE / 100; // 1.1
-        vm.prank(owner);
-        // half leverage
-        IdleLeveragedEulerStrategy(address(strategy)).deleverageManually(_targetHealthScore);
+//         uint256 _targetHealthScore = 2 * EXP_SCALE; // 1.1
+//         // uint256 _targetHealthScore = 110 * EXP_SCALE / 100; // 1.1
+//         vm.prank(owner);
+//         // half leverage
+//         IdleLeveragedEulerStrategy(address(strategy)).deleverageManually(_targetHealthScore);
         
-        assertEq(_getTargetHealthScore(), _targetHealthScore, 'target health score not updated');
-        assertApproxEqRel(
-            _getCurrentHealthScore(),
-            _targetHealthScore,
-            1e15, // 0.1%
-            'Current health does not match expected one'
-        );
-        assertGt(dToken.balanceOf(address(strategy)), 0, 'Current strategy has debt');
+//         assertEq(_getTargetHealthScore(), _targetHealthScore, 'target health score not updated');
+//         assertApproxEqRel(
+//             _getCurrentHealthScore(),
+//             _targetHealthScore,
+//             1e15, // 0.1%
+//             'Current health does not match expected one'
+//         );
+//         assertGt(dToken.balanceOf(address(strategy)), 0, 'Current strategy has debt');
 
-        idleCDO.depositAA(amount);
+//         idleCDO.depositAA(amount);
 
-        assertApproxEqRel(
-            _getCurrentHealthScore(),
-            _targetHealthScore,
-            1e15, // 0.1%
-            'Current target health does not match expected one after deposit'
-        );
-        assertGt(dToken.balanceOf(address(strategy)), 0, 'Current strategy has debt after another deposit');
-    }
+//         assertApproxEqRel(
+//             _getCurrentHealthScore(),
+//             _targetHealthScore,
+//             1e15, // 0.1%
+//             'Current target health does not match expected one after deposit'
+//         );
+//         assertGt(dToken.balanceOf(address(strategy)), 0, 'Current strategy has debt after another deposit');
+//     }
 
-    function testRedeemsWithRewards() external runOnForkingNetwork(MAINNET_CHIANID) {
-        uint256 amount = 10000 * ONE_SCALE;
-        idleCDO.depositAA(amount);
-        idleCDO.depositBB(amount);
-        uint256 pricePre = strategy.price();
-        // funds in lending
-        _cdoHarvest(true);
-        skip(7 days);
-        vm.roll(block.number + 1);
-        uint256 pricePost = strategy.price();
-        // here we didn't harvested any rewards and 
-        // borrow apy > supply apr so the strategy price decreases
-        assertLt(pricePost, pricePre, 'Strategy price correctly decreased');
+//     function testRedeemsWithRewards() external runOnForkingNetwork(MAINNET_CHIANID) {
+//         uint256 amount = 10000 * ONE_SCALE;
+//         idleCDO.depositAA(amount);
+//         idleCDO.depositBB(amount);
+//         uint256 pricePre = strategy.price();
+//         // funds in lending
+//         _cdoHarvest(true);
+//         skip(7 days);
+//         vm.roll(block.number + 1);
+//         uint256 pricePost = strategy.price();
+//         // here we didn't harvested any rewards and 
+//         // borrow apy > supply apr so the strategy price decreases
+//         assertLt(pricePost, pricePre, 'Strategy price correctly decreased');
  
-        // claim accrued euler tokens
-        _cdoHarvest(false);
-        skip(7 days);
-        vm.roll(block.number + _strategyReleaseBlocksPeriod() + 1);
+//         // claim accrued euler tokens
+//         _cdoHarvest(false);
+//         skip(7 days);
+//         vm.roll(block.number + _strategyReleaseBlocksPeriod() + 1);
 
-        idleCDO.withdrawAA(IERC20Detailed(address(AAtranche)).balanceOf(address(this)));
-        idleCDO.withdrawBB(IERC20Detailed(address(BBtranche)).balanceOf(address(this)));
+//         idleCDO.withdrawAA(IERC20Detailed(address(AAtranche)).balanceOf(address(this)));
+//         idleCDO.withdrawBB(IERC20Detailed(address(BBtranche)).balanceOf(address(this)));
 
-        assertEq(IERC20(AAtranche).balanceOf(address(this)), 0, "AAtranche bal");
-        assertEq(IERC20(BBtranche).balanceOf(address(this)), 0, "BBtranche bal");
-        assertGe(underlying.balanceOf(address(this)), initialBal, "underlying bal increased");
-    }
+//         assertEq(IERC20(AAtranche).balanceOf(address(this)), 0, "AAtranche bal");
+//         assertEq(IERC20(BBtranche).balanceOf(address(this)), 0, "BBtranche bal");
+//         assertGe(underlying.balanceOf(address(this)), initialBal, "underlying bal increased");
+//     }
 
-    function testRedeems() external override runOnForkingNetwork(MAINNET_CHIANID) {
-        uint256 amount = 10000 * ONE_SCALE;
-        idleCDO.depositAA(amount);
-        idleCDO.depositBB(amount);
-        uint256 pricePre = strategy.price();
-        // funds in lending
-        _cdoHarvest(true);
-        skip(7 days);
-        vm.roll(block.number + 1);
-        uint256 pricePost = strategy.price();
-        // here we didn't harvested any rewards and 
-        // borrow apy > supply apr so the strategy price decreases
-        assertLt(pricePost, pricePre, 'Strategy price correctly decreased');
+//     function testRedeems() external override runOnForkingNetwork(MAINNET_CHIANID) {
+//         uint256 amount = 10000 * ONE_SCALE;
+//         idleCDO.depositAA(amount);
+//         idleCDO.depositBB(amount);
+//         uint256 pricePre = strategy.price();
+//         // funds in lending
+//         _cdoHarvest(true);
+//         skip(7 days);
+//         vm.roll(block.number + 1);
+//         uint256 pricePost = strategy.price();
+//         // here we didn't harvested any rewards and 
+//         // borrow apy > supply apr so the strategy price decreases
+//         assertLt(pricePost, pricePre, 'Strategy price correctly decreased');
  
-        idleCDO.withdrawAA(IERC20Detailed(address(AAtranche)).balanceOf(address(this)));
-        idleCDO.withdrawBB(IERC20Detailed(address(BBtranche)).balanceOf(address(this)));
+//         idleCDO.withdrawAA(IERC20Detailed(address(AAtranche)).balanceOf(address(this)));
+//         idleCDO.withdrawBB(IERC20Detailed(address(BBtranche)).balanceOf(address(this)));
 
-        assertEq(IERC20(AAtranche).balanceOf(address(this)), 0, "AAtranche bal");
-        assertEq(IERC20(BBtranche).balanceOf(address(this)), 0, "BBtranche bal");
-        // balance should be less than the initial if no rewards are sold
-        assertLe(underlying.balanceOf(address(this)), initialBal, "underlying bal increased");
-    }
+//         assertEq(IERC20(AAtranche).balanceOf(address(this)), 0, "AAtranche bal");
+//         assertEq(IERC20(BBtranche).balanceOf(address(this)), 0, "BBtranche bal");
+//         // balance should be less than the initial if no rewards are sold
+//         assertLe(underlying.balanceOf(address(this)), initialBal, "underlying bal increased");
+//     }
 
-    function testGetSelfAmountToMint(uint32 target, uint32 unit) external runOnForkingNetwork(MAINNET_CHIANID) {
-        vm.assume(target > 1 && target <= 20);
-        vm.assume(unit > 100 && unit <= 10000);
+//     function testGetSelfAmountToMint(uint32 target, uint32 unit) external runOnForkingNetwork(MAINNET_CHIANID) {
+//         vm.assume(target > 1 && target <= 20);
+//         vm.assume(unit > 100 && unit <= 10000);
 
-        uint256 amount = unit * ONE_SCALE;
-        uint256 targetHealthScore = target * EXP_SCALE;
+//         uint256 amount = unit * ONE_SCALE;
+//         uint256 targetHealthScore = target * EXP_SCALE;
 
-        _strategyDeposit(targetHealthScore, amount);
+//         _strategyDeposit(targetHealthScore, amount);
 
-        assertLe(underlying.balanceOf(address(strategy)), 10);
+//         assertLe(underlying.balanceOf(address(strategy)), 10);
 
-        // maxPercentDelta 1e18 == 100%
-        assertApproxEqRel(
-            _getCurrentHealthScore(),
-            targetHealthScore,
-            1e15, // 0.1%
-            "!target health score before"
-        );
+//         // maxPercentDelta 1e18 == 100%
+//         assertApproxEqRel(
+//             _getCurrentHealthScore(),
+//             targetHealthScore,
+//             1e15, // 0.1%
+//             "!target health score before"
+//         );
 
-        _strategyDeposit(targetHealthScore, amount);
+//         _strategyDeposit(targetHealthScore, amount);
 
-        assertLe(underlying.balanceOf(address(strategy)), 10);
+//         assertLe(underlying.balanceOf(address(strategy)), 10);
 
-        // maxPercentDelta 1e18 == 100%
-        assertApproxEqRel(
-            _getCurrentHealthScore(),
-            targetHealthScore,
-            1e15, // 0.1%
-            "!target health score after"
-        );
-    }
+//         // maxPercentDelta 1e18 == 100%
+//         assertApproxEqRel(
+//             _getCurrentHealthScore(),
+//             targetHealthScore,
+//             1e15, // 0.1%
+//             "!target health score after"
+//         );
+//     }
 
-    function testLeverageAndDeleverageWithMint(uint256 target) external runOnForkingNetwork(MAINNET_CHIANID) {
-        vm.assume(target > 1 && target < 20);
+//     function testLeverageAndDeleverageWithMint(uint256 target) external runOnForkingNetwork(MAINNET_CHIANID) {
+//         vm.assume(target > 1 && target < 20);
 
-        uint256 amount = 10000 * ONE_SCALE;
-        uint256 initialTargetHealth = 20 * EXP_SCALE;
-        uint256 targetHealthScore = target * EXP_SCALE;
+//         uint256 amount = 10000 * ONE_SCALE;
+//         uint256 initialTargetHealth = 20 * EXP_SCALE;
+//         uint256 targetHealthScore = target * EXP_SCALE;
 
-        // first deposit
-        _strategyDeposit(initialTargetHealth, amount);
+//         // first deposit
+//         _strategyDeposit(initialTargetHealth, amount);
 
-        assertLe(underlying.balanceOf(address(strategy)), 10);
+//         assertLe(underlying.balanceOf(address(strategy)), 10);
 
-        // maxPercentDelta 1e18 == 100%
-        assertApproxEqRel(
-            _getCurrentHealthScore(),
-            initialTargetHealth,
-            1e15, // 0.1%
-            "!target health score"
-        );
+//         // maxPercentDelta 1e18 == 100%
+//         assertApproxEqRel(
+//             _getCurrentHealthScore(),
+//             initialTargetHealth,
+//             1e15, // 0.1%
+//             "!target health score"
+//         );
 
-        // leverage
-        _strategyDeposit(targetHealthScore, amount / 10);
+//         // leverage
+//         _strategyDeposit(targetHealthScore, amount / 10);
 
-        assertLe(underlying.balanceOf(address(strategy)), 10);
-        assertLe(_getCurrentHealthScore(), initialTargetHealth, "hs < initial hs");
+//         assertLe(underlying.balanceOf(address(strategy)), 10);
+//         assertLe(_getCurrentHealthScore(), initialTargetHealth, "hs < initial hs");
 
-        // deleverage
-        _strategyDeposit(initialTargetHealth, amount / 10);
+//         // deleverage
+//         _strategyDeposit(initialTargetHealth, amount / 10);
 
-        assertLe(underlying.balanceOf(address(strategy)), 10);
-        assertGe(_getCurrentHealthScore(), targetHealthScore, "hs > initial hs");
-    }
+//         assertLe(underlying.balanceOf(address(strategy)), 10);
+//         assertGe(_getCurrentHealthScore(), targetHealthScore, "hs > initial hs");
+//     }
 
-    function testGetSelfAmountToBurn(uint32 target, uint32 unit) external runOnForkingNetwork(MAINNET_CHIANID) {
-        vm.assume(target > 1 && target <= 20);
-        vm.assume(unit > 100 && unit <= 10000);
+//     function testGetSelfAmountToBurn(uint32 target, uint32 unit) external runOnForkingNetwork(MAINNET_CHIANID) {
+//         vm.assume(target > 1 && target <= 20);
+//         vm.assume(unit > 100 && unit <= 10000);
 
-        uint256 amount = unit * ONE_SCALE;
-        uint256 targetHealthScore = target * EXP_SCALE;
+//         uint256 amount = unit * ONE_SCALE;
+//         uint256 targetHealthScore = target * EXP_SCALE;
 
-        _strategyDeposit(targetHealthScore, amount);
+//         _strategyDeposit(targetHealthScore, amount);
 
-        uint256 amountAA = IERC20(AAtranche).balanceOf(address(this));
-        _strategyWithdraw(targetHealthScore, amountAA / 10);
+//         uint256 amountAA = IERC20(AAtranche).balanceOf(address(this));
+//         _strategyWithdraw(targetHealthScore, amountAA / 10);
 
-        assertLe(underlying.balanceOf(address(strategy)), 10);
-        assertApproxEqRel(
-            _getCurrentHealthScore(),
-            targetHealthScore,
-            1e15, // 0.1%
-            "!target health score before"
-        );
+//         assertLe(underlying.balanceOf(address(strategy)), 10);
+//         assertApproxEqRel(
+//             _getCurrentHealthScore(),
+//             targetHealthScore,
+//             1e15, // 0.1%
+//             "!target health score before"
+//         );
 
-        _strategyWithdraw(targetHealthScore, amountAA / 10);
+//         _strategyWithdraw(targetHealthScore, amountAA / 10);
 
-        assertLe(underlying.balanceOf(address(strategy)), 10);
-        assertApproxEqRel(
-            _getCurrentHealthScore(),
-            targetHealthScore,
-            1e15, // 0.1%
-            "!target health score after"
-        );
-    }
+//         assertLe(underlying.balanceOf(address(strategy)), 10);
+//         assertApproxEqRel(
+//             _getCurrentHealthScore(),
+//             targetHealthScore,
+//             1e15, // 0.1%
+//             "!target health score after"
+//         );
+//     }
 
-    function testLeverageAndDeleverageWithBurn(uint256 target) external runOnForkingNetwork(MAINNET_CHIANID) {
-        vm.assume(target > 1 && target < 20);
+//     function testLeverageAndDeleverageWithBurn(uint256 target) external runOnForkingNetwork(MAINNET_CHIANID) {
+//         vm.assume(target > 1 && target < 20);
 
-        uint256 amount = 10000 * ONE_SCALE;
-        uint256 initialTargetHealth = 20 * EXP_SCALE;
-        uint256 targetHealthScore = target * EXP_SCALE;
+//         uint256 amount = 10000 * ONE_SCALE;
+//         uint256 initialTargetHealth = 20 * EXP_SCALE;
+//         uint256 targetHealthScore = target * EXP_SCALE;
 
-        // first deposit
-        _strategyDeposit(initialTargetHealth, amount);
+//         // first deposit
+//         _strategyDeposit(initialTargetHealth, amount);
 
-        // leverage
-        uint256 amountAA = IERC20(AAtranche).balanceOf(address(this));
-        _strategyWithdraw(targetHealthScore, amountAA / 10);
+//         // leverage
+//         uint256 amountAA = IERC20(AAtranche).balanceOf(address(this));
+//         _strategyWithdraw(targetHealthScore, amountAA / 10);
 
-        assertLe(underlying.balanceOf(address(strategy)), 10);
-        assertLe(_getCurrentHealthScore(), initialTargetHealth, "hs < initial hs");
+//         assertLe(underlying.balanceOf(address(strategy)), 10);
+//         assertLe(_getCurrentHealthScore(), initialTargetHealth, "hs < initial hs");
 
-        // deleverage
-        _strategyWithdraw(initialTargetHealth, amountAA / 10);
+//         // deleverage
+//         _strategyWithdraw(initialTargetHealth, amountAA / 10);
 
-        assertLe(underlying.balanceOf(address(strategy)), 10);
-        assertGe(_getCurrentHealthScore(), targetHealthScore, "hs > initial hs");
-    }
+//         assertLe(underlying.balanceOf(address(strategy)), 10);
+//         assertGe(_getCurrentHealthScore(), targetHealthScore, "hs > initial hs");
+//     }
 
-    function testDefaultCheck() external runOnForkingNetwork(MAINNET_CHIANID) {
-        uint256 amount = 10000 * ONE_SCALE;
-        idleCDO.depositAA(amount);
-        idleCDO.depositBB(amount);
+//     function testDefaultCheck() external runOnForkingNetwork(MAINNET_CHIANID) {
+//         uint256 amount = 10000 * ONE_SCALE;
+//         idleCDO.depositAA(amount);
+//         idleCDO.depositBB(amount);
 
-        // funds in lending
-        _cdoHarvest(true);
-        // accrue some debt as no rewards are harvested
-        skip(365 days);
-        vm.roll(block.number + _strategyReleaseBlocksPeriod() + 1);
-        // try to exit the position but it will fail with status reason "4" (defaulted)
-        uint256 balAA = IERC20Detailed(address(AAtranche)).balanceOf(address(this));
-        vm.expectRevert(bytes('4'));
-        idleCDO.withdrawAA(balAA);
+//         // funds in lending
+//         _cdoHarvest(true);
+//         // accrue some debt as no rewards are harvested
+//         skip(365 days);
+//         vm.roll(block.number + _strategyReleaseBlocksPeriod() + 1);
+//         // try to exit the position but it will fail with status reason "4" (defaulted)
+//         uint256 balAA = IERC20Detailed(address(AAtranche)).balanceOf(address(this));
+//         vm.expectRevert(bytes('4'));
+//         idleCDO.withdrawAA(balAA);
 
-        uint256 balBB = IERC20Detailed(address(BBtranche)).balanceOf(address(this));
-        vm.expectRevert(bytes('4'));
-        idleCDO.withdrawBB(balBB);
-    }
+//         uint256 balBB = IERC20Detailed(address(BBtranche)).balanceOf(address(this));
+//         vm.expectRevert(bytes('4'));
+//         idleCDO.withdrawBB(balBB);
+//     }
 
-    function _strategyDeposit(uint256 targetHealthScore, uint256 amount) internal {
-        // set targetHealthScore
-        vm.prank(owner);
-        IdleLeveragedEulerStrategy(address(strategy)).setTargetHealthScore(targetHealthScore);
+//     function _strategyDeposit(uint256 targetHealthScore, uint256 amount) internal {
+//         // set targetHealthScore
+//         vm.prank(owner);
+//         IdleLeveragedEulerStrategy(address(strategy)).setTargetHealthScore(targetHealthScore);
 
-        idleCDO.depositAA(amount);
-        // deposit to Euler
-        _cdoHarvest(true);
-    }
+//         idleCDO.depositAA(amount);
+//         // deposit to Euler
+//         _cdoHarvest(true);
+//     }
 
-    function _strategyWithdraw(uint256 targetHealthScore, uint256 amountAA) internal {
-        // set targetHealthScore
-        vm.prank(owner);
-        IdleLeveragedEulerStrategy(address(strategy)).setTargetHealthScore(targetHealthScore);
+//     function _strategyWithdraw(uint256 targetHealthScore, uint256 amountAA) internal {
+//         // set targetHealthScore
+//         vm.prank(owner);
+//         IdleLeveragedEulerStrategy(address(strategy)).setTargetHealthScore(targetHealthScore);
 
-        uint256 amount = (amountAA * idleCDO.virtualPrice(address(AAtranche))) / 1e18;
-        uint256 amtToBurn = IdleLeveragedEulerStrategy(address(strategy)).getSelfAmountToBurn(
-            targetHealthScore,
-            amount
-        );
-        assertLe(amtToBurn, amount, "amtToBurn < amountAA");
+//         uint256 amount = (amountAA * idleCDO.virtualPrice(address(AAtranche))) / 1e18;
+//         uint256 amtToBurn = IdleLeveragedEulerStrategy(address(strategy)).getSelfAmountToBurn(
+//             targetHealthScore,
+//             amount
+//         );
+//         assertLe(amtToBurn, amount, "amtToBurn < amountAA");
 
-        idleCDO.withdrawAA(amountAA);
-    }
+//         idleCDO.withdrawAA(amountAA);
+//     }
 
-    function _getCurrentHealthScore() internal view returns (uint256) {
-        return IdleLeveragedEulerStrategy(address(strategy)).getCurrentHealthScore();
-    }
-    function _getTargetHealthScore() internal view returns (uint256) {
-        return IdleLeveragedEulerStrategy(address(strategy)).targetHealthScore();
-    }
+//     function _getCurrentHealthScore() internal view returns (uint256) {
+//         return IdleLeveragedEulerStrategy(address(strategy)).getCurrentHealthScore();
+//     }
+//     function _getTargetHealthScore() internal view returns (uint256) {
+//         return IdleLeveragedEulerStrategy(address(strategy)).targetHealthScore();
+//     }
 
-    function _getCurrentLeverage() internal view returns (uint256) {
-        return IdleLeveragedEulerStrategy(address(strategy)).getCurrentLeverage();
-    }
+//     function _getCurrentLeverage() internal view returns (uint256) {
+//         return IdleLeveragedEulerStrategy(address(strategy)).getCurrentLeverage();
+//     }
 
-    function testSetInvalidTargetHealthScore() public runOnForkingNetwork(MAINNET_CHIANID) {
-        vm.prank(owner);
-        vm.expectRevert(bytes("strat/invalid-target-hs"));
-        IdleLeveragedEulerStrategy(address(strategy)).setTargetHealthScore(1e18);
-    }
+//     function testSetInvalidTargetHealthScore() public runOnForkingNetwork(MAINNET_CHIANID) {
+//         vm.prank(owner);
+//         vm.expectRevert(bytes("strat/invalid-target-hs"));
+//         IdleLeveragedEulerStrategy(address(strategy)).setTargetHealthScore(1e18);
+//     }
 
-    function testOnlyOwner() public override runOnForkingNetwork(MAINNET_CHIANID) {
-        super.testOnlyOwner();
+//     function testOnlyOwner() public override runOnForkingNetwork(MAINNET_CHIANID) {
+//         super.testOnlyOwner();
 
-        IdleLeveragedEulerStrategy _strategy = IdleLeveragedEulerStrategy(address(strategy));
-        vm.startPrank(address(0xbabe));
-        vm.expectRevert(bytes("!AUTH"));
-        _strategy.setTargetHealthScore(2e18);
+//         IdleLeveragedEulerStrategy _strategy = IdleLeveragedEulerStrategy(address(strategy));
+//         vm.startPrank(address(0xbabe));
+//         vm.expectRevert(bytes("!AUTH"));
+//         _strategy.setTargetHealthScore(2e18);
 
-        vm.expectRevert(bytes("Ownable: caller is not the owner"));
-        _strategy.setEulDistributor(address(0xabcd));
+//         vm.expectRevert(bytes("Ownable: caller is not the owner"));
+//         _strategy.setEulDistributor(address(0xabcd));
 
-        vm.expectRevert(bytes("Ownable: caller is not the owner"));
-        _strategy.setSwapRouter(address(0xabcd));
+//         vm.expectRevert(bytes("Ownable: caller is not the owner"));
+//         _strategy.setSwapRouter(address(0xabcd));
 
-        vm.expectRevert(bytes("Ownable: caller is not the owner"));
-        _strategy.setRebalancer(address(22));
+//         vm.expectRevert(bytes("Ownable: caller is not the owner"));
+//         _strategy.setRebalancer(address(22));
 
-        vm.expectRevert(bytes("Ownable: caller is not the owner"));
-        _strategy.setRouterPath(path);
+//         vm.expectRevert(bytes("Ownable: caller is not the owner"));
+//         _strategy.setRouterPath(path);
 
-        vm.expectRevert(bytes("!AUTH"));
-        _strategy.deleverageManually(2e18);
+//         vm.expectRevert(bytes("!AUTH"));
+//         _strategy.deleverageManually(2e18);
 
-        vm.expectRevert(bytes("!AUTH"));
-        _strategy.leverageManually(2e18);
-        vm.stopPrank();
-    }
+//         vm.expectRevert(bytes("!AUTH"));
+//         _strategy.leverageManually(2e18);
+//         vm.stopPrank();
+//     }
 
-    function testOnlyRebalancer() public runOnForkingNetwork(MAINNET_CHIANID) {
-        IdleLeveragedEulerStrategy _strategy = IdleLeveragedEulerStrategy(address(strategy));
-        vm.prank(owner);
-        _strategy.setRebalancer(address(0xdead));
+//     function testOnlyRebalancer() public runOnForkingNetwork(MAINNET_CHIANID) {
+//         IdleLeveragedEulerStrategy _strategy = IdleLeveragedEulerStrategy(address(strategy));
+//         vm.prank(owner);
+//         _strategy.setRebalancer(address(0xdead));
         
-        vm.startPrank(address(0xbabe));
-        vm.expectRevert(bytes("!AUTH"));
-        _strategy.setTargetHealthScore(2e18);
+//         vm.startPrank(address(0xbabe));
+//         vm.expectRevert(bytes("!AUTH"));
+//         _strategy.setTargetHealthScore(2e18);
 
-        vm.expectRevert(bytes("!AUTH"));
-        _strategy.deleverageManually(2e18);
-        vm.stopPrank();
+//         vm.expectRevert(bytes("!AUTH"));
+//         _strategy.deleverageManually(2e18);
+//         vm.stopPrank();
 
-        idleCDO.depositAA(1000 * ONE_SCALE);
-        _cdoHarvest(true, true);
+//         idleCDO.depositAA(1000 * ONE_SCALE);
+//         _cdoHarvest(true, true);
 
-        vm.startPrank(address(0xdead));
-        _strategy.setTargetHealthScore(2e18);
-        _strategy.leverageManually(2e18);
-        _strategy.deleverageManually(0);
-        vm.stopPrank();
-    }
+//         vm.startPrank(address(0xdead));
+//         _strategy.setTargetHealthScore(2e18);
+//         _strategy.leverageManually(2e18);
+//         _strategy.deleverageManually(0);
+//         vm.stopPrank();
+//     }
 
-    function testCantReinitialize() external override runOnForkingNetwork(MAINNET_CHIANID) {
-        vm.expectRevert(bytes("Initializable: contract is already initialized"));
-        IdleLeveragedEulerStrategy(address(strategy)).initialize(
-            address(0xbabe),
-            address(eToken),
-            address(dToken),
-            address(underlying),
-            owner,
-            address(eulDistributor),
-            address(router),
-            hex"",
-            INITIAL_TARGET_HEALTH
-        );
-    }
+//     function testCantReinitialize() external override runOnForkingNetwork(MAINNET_CHIANID) {
+//         vm.expectRevert(bytes("Initializable: contract is already initialized"));
+//         IdleLeveragedEulerStrategy(address(strategy)).initialize(
+//             address(0xbabe),
+//             address(eToken),
+//             address(dToken),
+//             address(underlying),
+//             owner,
+//             address(eulDistributor),
+//             address(router),
+//             hex"",
+//             INITIAL_TARGET_HEALTH
+//         );
+//     }
 
-    function _cdoHarvest(bool _skipRewards, bool _skipRelease) internal {
-        uint256 numOfRewards = rewards.length;
-        bool[] memory _skipFlags = new bool[](4);
-        bool[] memory _skipReward = new bool[](numOfRewards);
-        uint256[] memory _minAmount = new uint256[](numOfRewards);
-        uint256[] memory _sellAmounts = new uint256[](numOfRewards);
-        bytes[] memory _extraData = new bytes[](2);
-        // bytes memory _extraData = abi.encode(uint256(0), uint256(0), uint256(0));
-        if(!_skipRewards){
-            _extraData[0] = extraData;
-            _extraData[1] = extraDataSell;
-        }
-        // skip fees distribution
-        _skipFlags[3] = _skipRewards;
+//     function _cdoHarvest(bool _skipRewards, bool _skipRelease) internal {
+//         uint256 numOfRewards = rewards.length;
+//         bool[] memory _skipFlags = new bool[](4);
+//         bool[] memory _skipReward = new bool[](numOfRewards);
+//         uint256[] memory _minAmount = new uint256[](numOfRewards);
+//         uint256[] memory _sellAmounts = new uint256[](numOfRewards);
+//         bytes[] memory _extraData = new bytes[](2);
+//         // bytes memory _extraData = abi.encode(uint256(0), uint256(0), uint256(0));
+//         if(!_skipRewards){
+//             _extraData[0] = extraData;
+//             _extraData[1] = extraDataSell;
+//         }
+//         // skip fees distribution
+//         _skipFlags[3] = _skipRewards;
 
-        vm.prank(idleCDO.rebalancer());
-        idleCDO.harvest(_skipFlags, _skipReward, _minAmount, _sellAmounts, _extraData);
+//         vm.prank(idleCDO.rebalancer());
+//         idleCDO.harvest(_skipFlags, _skipReward, _minAmount, _sellAmounts, _extraData);
 
-        // linearly release all sold rewards
-        if (!_skipRelease) {
-            vm.roll(block.number + idleCDO.releaseBlocksPeriod() + 1); 
-        }
-    }
-}
+//         // linearly release all sold rewards
+//         if (!_skipRelease) {
+//             vm.roll(block.number + idleCDO.releaseBlocksPeriod() + 1); 
+//         }
+//     }
+// }
 
-contract EulDistributorMock is IEulDistributor {
-    /// @notice Claim distributed tokens
-    /// @param account Address that should receive tokens
-    /// @param token Address of token being claimed (ie EUL)
-    /// @param - Merkle proof that validates this claim
-    /// @param - If non-zero, then the address of a token to auto-stake to, instead of claiming
-    function claim(
-        address account,
-        address token,
-        uint256 claimable,
-        bytes32[] calldata,
-        address
-    ) external {
-        IERC20Detailed(token).transfer(account, claimable);
-    }
-    function claimed(address, address) external view returns (uint256) {}
-}
+// contract EulDistributorMock is IEulDistributor {
+//     /// @notice Claim distributed tokens
+//     /// @param account Address that should receive tokens
+//     /// @param token Address of token being claimed (ie EUL)
+//     /// @param - Merkle proof that validates this claim
+//     /// @param - If non-zero, then the address of a token to auto-stake to, instead of claiming
+//     function claim(
+//         address account,
+//         address token,
+//         uint256 claimable,
+//         bytes32[] calldata,
+//         address
+//     ) external {
+//         IERC20Detailed(token).transfer(account, claimable);
+//     }
+//     function claimed(address, address) external view returns (uint256) {}
+// }

--- a/test/foundry/TestIdleCDODefaulMgmt.sol
+++ b/test/foundry/TestIdleCDODefaulMgmt.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.10;
+import "../../contracts/interfaces/ICToken.sol";
+import "../../contracts/interfaces/IIdleCDOStrategy.sol";
+import "../../contracts/strategies/idle/IdleStrategy.sol";
+import "../../contracts/IdleTokenFungible.sol";
+import "../../contracts/IdleCDO.sol";
+import "./TestIdleCDOBase.sol";
+import "../../contracts/interfaces/IProxyAdmin.sol";
+import "forge-std/Test.sol";
+
+contract TestIdleCDODefaultMgmt is Test {
+  using stdStorage for StdStorage;
+  using SafeERC20Upgradeable for IERC20Detailed;
+
+  // Idle-USDC Best-Yield v4
+  address internal constant UNDERLYING = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+  address internal constant idleToken = 0x5274891bEC421B39D23760c04A6755eCB444797C;
+  address internal constant idleTokenJunior = 0xDc7777C771a6e4B3A82830781bDDe4DBC78f320e;
+  address internal constant aToken = 0xBcca60bB61934080951369a648Fb03DF4F96263C;
+  address internal constant maToken = 0xA5269A8e31B93Ff27B887B56720A25F844db0529;
+  address internal constant cdo = 0xf615a552c000B114DdAa09636BBF4205De49333c;
+
+  // uint256 internal constant BLOCK_FOR_TEST = 16818361; // pre Euler pause otherwise revert
+  uint256 internal constant BLOCK_FOR_TEST = 16814098; // pre Euler hack
+  IdleCDO public idleCDO = IdleCDO(cdo);
+  IdleTokenFungible public _idleToken = IdleTokenFungible(idleToken);
+  IdleTokenFungible public _idleTokenJunior = IdleTokenFungible(idleTokenJunior);
+  uint256 public initialContractValue;
+
+  function setUp() public virtual {
+    _forkAt(BLOCK_FOR_TEST);
+
+    deal(UNDERLYING, address(this), 101_000 * 1e6);
+    IERC20Detailed(UNDERLYING).approve(cdo, type(uint256).max);
+    idleCDO.depositAA(100_000 * 1e6);
+    idleCDO.depositBB(1_000 * 1e6);
+
+    // set all allocations to aave (cUSDC is paused at this block)
+    uint256[] memory allocs = new uint256[](3);
+    (allocs[0], allocs[1], allocs[2]) = (0, 100000, 0);
+    vm.prank(_idleToken.rebalancer());
+    _idleToken.setAllocations(allocs);
+
+    // set all allocations to morpho aave
+    uint256[] memory allocsJun = new uint256[](2);
+    (allocsJun[0], allocsJun[1]) = (0, 100000);
+    vm.prank(_idleTokenJunior.rebalancer());
+    _idleTokenJunior.setAllocations(allocsJun);
+
+    initialContractValue = idleCDO.getContractValue();
+
+    // trigger shutdown and pause on BY to simulate last state
+    vm.prank(idleCDO.owner());
+    idleCDO.emergencyShutdown();
+  }
+
+  function _forkAt(uint256 _block) internal {
+    vm.selectFork(vm.createFork(vm.envString("ETH_RPC_URL"), _block));
+  }
+
+  function _upgradeContract(address proxy, address newInstance) internal {
+    // Upgrade the proxy to the new contract
+    IProxyAdmin admin = IProxyAdmin(0x9438904ABC7d8944A6E2A89671fEf51C629af351);
+    vm.prank(admin.owner());
+    admin.upgrade(proxy, newInstance);
+  }
+
+  function testSetRedemptioRates() external {
+    _upgradeContract(cdo, address(new IdleCDO()));
+    IIdleCDOStrategy strategy = IIdleCDOStrategy(IdleCDO(cdo).strategy());
+
+    // now let's simulate a loss by decreasing strategy price
+    // curr price - ~50%
+    vm.mockCall(
+      address(strategy),
+      abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
+      abi.encode(5e5) // 0.5 underlyings
+    );
+
+    uint256 postAAPrice = idleCDO.virtualPrice(idleCDO.AATranche());
+    uint256 postBBPrice = idleCDO.virtualPrice(idleCDO.BBTranche());
+    assertEq(idleCDO.priceAA(), postAAPrice, 'AA price changed');
+    assertEq(idleCDO.priceBB(), postBBPrice, 'BB price changed');
+
+    vm.startPrank(idleCDO.owner());
+    idleCDO.setRedemptionRates();
+    idleCDO.setAllowAAWithdraw(true);
+    idleCDO.setAllowBBWithdraw(true);
+    vm.stopPrank();
+
+    uint256 redemptionRateAA = idleCDO.virtualPrice(idleCDO.AATranche());
+    uint256 redemptionRateBB = idleCDO.virtualPrice(idleCDO.BBTranche());
+
+    // assertLt(redemptionRateAA, postAAPrice, 'AA did not decrease');
+    assertApproxEqAbs(
+      redemptionRateAA, 
+      postAAPrice / 2,
+      1e5, // 0.1 underlyings so price between ~0.4 and ~0.6 
+      'AA did not decrease'
+    );
+    // seniors are way more than juniors
+    assertEq(redemptionRateBB, 0, 'BB should be 0');
+
+    // test multiple redeems AA
+    // redeem with BY
+    vm.roll(block.number + 1);
+    uint256 balPre = IERC20Detailed(aToken).balanceOf(idleToken);
+    _idleToken.rebalance();
+    // all balance is now in aave 
+    uint256 balPost = IERC20Detailed(aToken).balanceOf(idleToken);
+    // aToken price is 1, we had about 4.6M so with a tokenPrice of 0.5 we should have 2.3M
+    assertApproxEqAbs(balPost - balPre, initialContractValue / 2, 50_000 * 1e6, 'aToken bal is not half the initial val');
+    // tranche price should not change
+    assertEq(idleCDO.priceAA(), redemptionRateAA, 'AA price changed');
+    assertEq(idleCDO.priceBB(), redemptionRateBB, 'BB price changed');
+
+    vm.clearMockedCalls();
+
+    // We now simulate and increase in eToken price to test
+    // curr price - ~10%
+    vm.mockCall(
+      address(strategy),
+      abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
+      abi.encode(9e5) // 0.9 underlyings
+    );
+
+    vm.roll(block.number + 1);
+    // test another redeem AA (we deposited 100k on setUp)
+    balPre = IERC20Detailed(UNDERLYING).balanceOf(address(this));
+    idleCDO.withdrawAA(0);
+    balPost = IERC20Detailed(UNDERLYING).balanceOf(address(this));
+    assertApproxEqAbs(balPost - balPre, 50_000 * 1e6, 5_000 * 1e6, 'underlying bal is not 0.5M');
+
+    // tranche price should not change
+    assertEq(idleCDO.priceAA(), redemptionRateAA, 'AA price changed');
+    assertEq(idleCDO.priceBB(), redemptionRateBB, 'BB price changed');
+
+    // test multiple redeem BB
+    vm.roll(block.number + 1);
+
+    // redeem with BY junior
+    balPre = IERC20Detailed(maToken).balanceOf(idleTokenJunior);
+    _idleTokenJunior.rebalance();
+    balPost = IERC20Detailed(maToken).balanceOf(idleTokenJunior);
+    assertEq(balPost - balPre, 0, 'maToken bal diff should be 0');
+
+    // redeem with this contract
+    balPre = IERC20Detailed(UNDERLYING).balanceOf(address(this));
+    idleCDO.withdrawBB(0);
+    balPost = IERC20Detailed(UNDERLYING).balanceOf(address(this));
+    assertEq(balPost - balPre, 0, 'juniors bal diff should be 0');
+
+    vm.clearMockedCalls();
+  }
+}

--- a/test/foundry/TestIdleCDODefaulMgmt.sol
+++ b/test/foundry/TestIdleCDODefaulMgmt.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.10;
-import "../../contracts/interfaces/ICToken.sol";
 import "../../contracts/interfaces/IIdleCDOStrategy.sol";
 import "../../contracts/strategies/idle/IdleStrategy.sol";
+import "../../contracts/strategies/euler/IdleEulerStakingStrategy.sol";
+import "../../contracts/strategies/euler/IdleEulerStrategy.sol";
 import "../../contracts/IdleTokenFungible.sol";
 import "../../contracts/IdleCDO.sol";
 import "./TestIdleCDOBase.sol";
@@ -14,45 +15,18 @@ contract TestIdleCDODefaultMgmt is Test {
   using SafeERC20Upgradeable for IERC20Detailed;
 
   // Idle-USDC Best-Yield v4
-  address internal constant UNDERLYING = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
-  address internal constant idleToken = 0x5274891bEC421B39D23760c04A6755eCB444797C;
-  address internal constant idleTokenJunior = 0xDc7777C771a6e4B3A82830781bDDe4DBC78f320e;
-  address internal constant aToken = 0xBcca60bB61934080951369a648Fb03DF4F96263C;
-  address internal constant maToken = 0xA5269A8e31B93Ff27B887B56720A25F844db0529;
-  address internal constant cdo = 0xf615a552c000B114DdAa09636BBF4205De49333c;
-
-  // uint256 internal constant BLOCK_FOR_TEST = 16818361; // pre Euler pause otherwise revert
-  uint256 internal constant BLOCK_FOR_TEST = 16814098; // pre Euler hack
-  IdleCDO public idleCDO = IdleCDO(cdo);
-  IdleTokenFungible public _idleToken = IdleTokenFungible(idleToken);
-  IdleTokenFungible public _idleTokenJunior = IdleTokenFungible(idleTokenJunior);
-  uint256 public initialContractValue;
+  address internal constant DEV_MULTISIG = 0xe8eA8bAE250028a8709A3841E0Ae1a44820d677b;
+  address internal constant GUARDIAN_MULTISIG = 0xaDa343Cb6820F4f5001749892f6CAA9920129F2A;  
+  uint256 internal constant PRE_EULER_PAUSE = 16818362; // pre hack
+  uint256 internal constant BLOCK_FOR_TEST = 17065314; // post recovery
+  address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+  address internal constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+  address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+  address internal constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+  address internal constant AGEUR = 0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8;
 
   function setUp() public virtual {
-    _forkAt(BLOCK_FOR_TEST);
-
-    deal(UNDERLYING, address(this), 101_000 * 1e6);
-    IERC20Detailed(UNDERLYING).approve(cdo, type(uint256).max);
-    idleCDO.depositAA(100_000 * 1e6);
-    idleCDO.depositBB(1_000 * 1e6);
-
-    // set all allocations to aave (cUSDC is paused at this block)
-    uint256[] memory allocs = new uint256[](3);
-    (allocs[0], allocs[1], allocs[2]) = (0, 100000, 0);
-    vm.prank(_idleToken.rebalancer());
-    _idleToken.setAllocations(allocs);
-
-    // set all allocations to morpho aave
-    uint256[] memory allocsJun = new uint256[](2);
-    (allocsJun[0], allocsJun[1]) = (0, 100000);
-    vm.prank(_idleTokenJunior.rebalancer());
-    _idleTokenJunior.setAllocations(allocsJun);
-
-    initialContractValue = idleCDO.getContractValue();
-
-    // trigger shutdown and pause on BY to simulate last state
-    vm.prank(idleCDO.owner());
-    idleCDO.emergencyShutdown();
+    _forkAt(PRE_EULER_PAUSE);
   }
 
   function _forkAt(uint256 _block) internal {
@@ -66,91 +40,298 @@ contract TestIdleCDODefaultMgmt is Test {
     admin.upgrade(proxy, newInstance);
   }
 
-  function testSetRedemptioRates() external {
-    _upgradeContract(cdo, address(new IdleCDO()));
-    IIdleCDOStrategy strategy = IIdleCDOStrategy(IdleCDO(cdo).strategy());
+  function testRedeemsUSDCStaking() public {
+    uint256 amount = 4667395913064; // eulerusdcstaking PYT
+    address cdo = 0xf615a552c000B114DdAa09636BBF4205De49333c;
+    address idleTokenSenior = 0x5274891bEC421B39D23760c04A6755eCB444797C;
+    address idleTokenJunior = 0xDc7777C771a6e4B3A82830781bDDe4DBC78f320e;
 
-    // now let's simulate a loss by decreasing strategy price
-    // curr price - ~50%
-    vm.mockCall(
-      address(strategy),
-      abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
-      abi.encode(5e5) // 0.5 underlyings
+    IdleCDO idleCDO = IdleCDO(cdo);
+    IdleTokenFungible _idleToken = IdleTokenFungible(idleTokenSenior);
+    IdleTokenFungible _idleTokenJunior = IdleTokenFungible(idleTokenJunior);
+
+    // set all allocations to aave
+    uint256[] memory allocs = new uint256[](3);
+    (allocs[0], allocs[1], allocs[2]) = (0, 100000, 0);
+    vm.prank(_idleToken.rebalancer());
+    _idleToken.setAllocations(allocs);
+
+    // set all allocations to morpho aave
+    uint256[] memory allocsJun = new uint256[](2);
+    (allocsJun[0], allocsJun[1]) = (0, 100000);
+    vm.prank(_idleTokenJunior.rebalancer());
+    _idleTokenJunior.setAllocations(allocsJun);
+  
+    _genericRedeemStakingTest(USDC, amount, idleCDO, _idleToken, _idleTokenJunior);
+  }
+
+  function testRedeemsUSDTStaking() public {
+    uint256 amount = 458120705798; // eulerusdtstaking PYT
+    address cdo = 0x860B1d25903DbDFFEC579d30012dA268aEB0d621;
+    address idleTokenSenior = 0xF34842d05A1c888Ca02769A633DF37177415C2f8;
+    address idleTokenJunior = 0xfa3AfC9a194BaBD56e743fA3b7aA2CcbED3eAaad;
+
+    IdleCDO idleCDO = IdleCDO(cdo);
+    IdleTokenFungible _idleToken = IdleTokenFungible(idleTokenSenior);
+    IdleTokenFungible _idleTokenJunior = IdleTokenFungible(idleTokenJunior);
+
+    // set all allocations to aave
+    uint256[] memory allocs = new uint256[](3);
+    (allocs[0], allocs[1], allocs[2]) = (0, 100000, 0);
+    vm.prank(_idleToken.rebalancer());
+    _idleToken.setAllocations(allocs);
+
+    // set all allocations to morpho aave
+    uint256[] memory allocsJun = new uint256[](2);
+    (allocsJun[0], allocsJun[1]) = (0, 100000);
+    vm.prank(_idleTokenJunior.rebalancer());
+    _idleTokenJunior.setAllocations(allocsJun);
+  
+    _genericRedeemStakingTest(USDT, amount, idleCDO, _idleToken, _idleTokenJunior);
+  }
+
+  function testRedeemsWETHStaking() public {
+    uint256 amount = 321324195182366363917; // eulerwethstaking PYT
+    address cdo = 0xec964d06cD71a68531fC9D083a142C48441F391C;
+    address idleTokenSenior = 0xC8E6CA6E96a326dC448307A5fDE90a0b21fd7f80;
+    address idleTokenJunior = 0x62A0369c6BB00054E589D12aaD7ad81eD789514b;
+
+    IdleCDO idleCDO = IdleCDO(cdo);
+    IdleTokenFungible _idleToken = IdleTokenFungible(idleTokenSenior);
+    IdleTokenFungible _idleTokenJunior = IdleTokenFungible(idleTokenJunior);
+
+    // set all allocations to aave
+    uint256[] memory allocs = new uint256[](3);
+    (allocs[0], allocs[1], allocs[2]) = (0, 100000, 0);
+    vm.prank(_idleToken.rebalancer());
+    _idleToken.setAllocations(allocs);
+
+    // set all allocations to morpho aave
+    uint256[] memory allocsJun = new uint256[](2);
+    (allocsJun[0], allocsJun[1]) = (0, 100000);
+    vm.prank(_idleTokenJunior.rebalancer());
+    _idleTokenJunior.setAllocations(allocsJun);
+  
+    _genericRedeemStakingTest(WETH, amount, idleCDO, _idleToken, _idleTokenJunior);
+  }
+
+  function testRedeemsUSDC() public {
+    uint256 amount = 39572620928; // eulerusdc PYT
+    address cdo = 0xF5a3d259bFE7288284Bd41823eC5C8327a314054;
+    address[] memory users = new address[](2);
+    (users[0], users[1]) = (
+      0x442Aea0Fd2AFbd3391DAE768F7046f132F0a6300, 
+      0x3F0a27C1bFF8e1AcaB07e688E52406Ab9c326be5
     );
+    _genericRedeemTest(USDC, amount, IdleCDO(cdo), users);
+  }
 
-    uint256 postAAPrice = idleCDO.virtualPrice(idleCDO.AATranche());
-    uint256 postBBPrice = idleCDO.virtualPrice(idleCDO.BBTranche());
-    assertEq(idleCDO.priceAA(), postAAPrice, 'AA price changed');
-    assertEq(idleCDO.priceBB(), postBBPrice, 'BB price changed');
+  function testRedeemsUSDT() public {
+    uint256 amount = 1121131420; // eulerusdt PYT
+    address cdo = 0xD5469DF8CA36E7EaeDB35D428F28E13380eC8ede;
+    address[] memory users = new address[](2);
+    (users[0], users[1]) = (
+      0x442Aea0Fd2AFbd3391DAE768F7046f132F0a6300, 
+      0x8997e31E7E93b8B7E70A157F42CD44B2eFD78220
+    );
+    _genericRedeemTest(USDT, amount, IdleCDO(cdo), users);
+  }
+
+  function testRedeemsDAI() public {
+    uint256 amount = 669187816235681547267; // eulerusdc PYT
+    address cdo = 0x46c1f702A6aAD1Fd810216A5fF15aaB1C62ca826;
+    address[] memory users = new address[](2);
+    (users[0], users[1]) = (
+      0x442Aea0Fd2AFbd3391DAE768F7046f132F0a6300, 
+      0xc286b8926c15E2509629f2209C2D57dec12E4ff8
+    );
+    _genericRedeemTest(DAI, amount, IdleCDO(cdo), users);
+  }
+
+  function testRedeemsAGEUR() public {
+    uint256 amount = 250297909170804501147234; // eulerusdc PYT
+    address cdo = 0x2398Bc075fa62Ee88d7fAb6A18Cd30bFf869bDa4;
+    address[] memory users = new address[](2);
+    (users[0], users[1]) = (
+      0xdC4e6DFe07EFCa50a197DF15D9200883eF4Eb1c8, 
+      0x442Aea0Fd2AFbd3391DAE768F7046f132F0a6300
+    );
+    _genericRedeemTest(AGEUR, amount, IdleCDO(cdo), users);
+  }
+
+  function _genericRedeemTest(
+    address under, 
+    uint256 amount, 
+    IdleCDO idleCDO,
+    address[] memory users
+  ) internal {
+    address AA = idleCDO.AATranche();
+    address BB = idleCDO.BBTranche();
+    // fetch prices pre hack
+    uint256 preAAPrice = idleCDO.virtualPrice(AA);
+    uint256 preBBPrice = idleCDO.virtualPrice(BB);
+
+    // fetch user tranches value before hack 
+    uint256[] memory preUserAA = new uint256[](users.length);
+    uint256[] memory preUserBB = new uint256[](users.length);
+    for (uint256 i = 0; i < users.length; i++) {
+      preUserAA[i] = IERC20Detailed(AA).balanceOf(users[i]) * preAAPrice / 1e18;
+      preUserBB[i] = IERC20Detailed(BB).balanceOf(users[i]) * preBBPrice / 1e18;
+    }
+
+    // for at current block, post hack
+    _forkAt(BLOCK_FOR_TEST);
+
+    // Upgrade strategy. strategy price and apr will be set to 0
+    _upgradeContract(IdleCDO(address(idleCDO)).strategy(), address(new IdleEulerStrategy()));
+    // NOTE: we upgrade also CDO here to remove calls to eToken contract
+    _upgradeContract(address(idleCDO), address(new IdleCDO()));
+    // send funds from dev multisig to cdo. Amount is calculated at block 16818362
+    vm.prank(DEV_MULTISIG);
+    IERC20Detailed(under).safeTransfer(address(idleCDO), amount);
+
+    // check that price did not decrease
+    uint256 postAAPrice = idleCDO.virtualPrice(AA);
+    uint256 postBBPrice = idleCDO.virtualPrice(BB);
+    assertGe(postAAPrice, preAAPrice, 'AA price did not decrease');
+    assertGe(postBBPrice, preBBPrice, 'BB price did not decrease');
 
     vm.startPrank(idleCDO.owner());
-    idleCDO.setRedemptionRates();
     idleCDO.setAllowAAWithdraw(true);
     idleCDO.setAllowBBWithdraw(true);
     vm.stopPrank();
 
-    uint256 redemptionRateAA = idleCDO.virtualPrice(idleCDO.AATranche());
-    uint256 redemptionRateBB = idleCDO.virtualPrice(idleCDO.BBTranche());
+    // redeem with all users
+    uint256 redeemed;
+    for (uint256 i = 0; i < users.length; i++) {
+      vm.startPrank(users[i]);
+      // check if has AA or BB tranches
+      if (IERC20Detailed(idleCDO.AATranche()).balanceOf(users[i]) > 0) {
+        redeemed = idleCDO.withdrawAA(0);
+        // check that redeemed value is >= preUserAA
+        assertGe(redeemed, preUserAA[i], 'AA redeemed value is less than pre hack');
+      } else {
+        redeemed = idleCDO.withdrawBB(0);
+        // check that redeemed value is >= preUserBB
+        assertGe(redeemed, preUserBB[i], 'BB redeemed value is less than pre hack');
+      }
+      vm.stopPrank();
+    }
 
-    // assertLt(redemptionRateAA, postAAPrice, 'AA did not decrease');
-    assertApproxEqAbs(
-      redemptionRateAA, 
-      postAAPrice / 2,
-      1e5, // 0.1 underlyings so price between ~0.4 and ~0.6 
-      'AA did not decrease'
-    );
-    // seniors are way more than juniors
-    assertEq(redemptionRateBB, 0, 'BB should be 0');
+    // check that price is equal to preXXPrices
+    uint256 postAAPrice2 = idleCDO.virtualPrice(AA);
+    uint256 postBBPrice2 = idleCDO.virtualPrice(BB);
+    // NOTE: this branch is needed because AGEUR PYT has only 2 users so when
+    // they both redeem the price will be 1
+    if (under != AGEUR) {
+      assertEq(postAAPrice2, preAAPrice, 'AA price changed');
+    }
+    assertEq(postBBPrice2, preBBPrice, 'BB price changed');
+  }
 
-    // test multiple redeems AA
-    // redeem with BY
+  struct VaultDatas {
+    address AA;
+    address BB;
+    uint256 AAPrice;
+    uint256 BBPrice;
+    uint256 BYPriceAA;
+    uint256 BYPriceBB;
+    uint256 UserAA;
+    uint256 UserBB;
+  }
+
+  // @notice we test both junior and senior BY redeems to check that everything is working
+  // with multiple redeems for the same PYT
+  // @dev we use a struct here to avoid stack too deep error
+  function _genericRedeemStakingTest(
+    address under, 
+    uint256 amount, 
+    IdleCDO idleCDO, 
+    IdleTokenFungible _idleToken,
+    IdleTokenFungible _idleTokenJunior
+  ) internal {
+    // fetch data pre Euler pause
+    VaultDatas memory preData = _fetchDatas(idleCDO, _idleToken, _idleTokenJunior);
+    // fork at recent block, post hack, post rescue
+    _forkAt(BLOCK_FOR_TEST);
+    // Upgrade strategy. Strategy price will be set to 0
+    _upgradeContract(IdleCDO(address(idleCDO)).strategy(), address(new IdleEulerStakingStrategy()));
+    // send funds from dev multisig to cdo. Amount is calculated at PRE_EULER_PAUSE block
+    vm.prank(DEV_MULTISIG);
+    IERC20Detailed(under).safeTransfer(address(idleCDO), amount);
+
+    // refetch datas post transfer
+    VaultDatas memory postData = _fetchDatas(idleCDO, _idleToken, _idleTokenJunior);
+    // post values should be >= pre values
+    assertGe(postData.AAPrice, preData.AAPrice, 'AA price decreased');
+    assertGe(postData.BBPrice, preData.BBPrice, 'BB price decreased');
+    assertGe(postData.BYPriceAA, preData.BYPriceAA, 'BY AA price decreased');
+    assertGe(postData.BYPriceBB, preData.BYPriceBB, 'BY BB price decreased');
+    assertGe(postData.UserBB, preData.UserBB, 'BY BB user value decreased');
+
+    // NOTE: this is not true on all BY seniors which uses staking because some 
+    // users redeemed interest bearing tokens so the contract value decreased
+    // assertGe(postData.UserAA, preData.UserAA, 'BY AA user value decreased');
+
+    // unpause PYT contract
+    vm.startPrank(idleCDO.owner());
+    idleCDO.setAllowAAWithdraw(true);
+    idleCDO.setAllowBBWithdraw(true);
+    vm.stopPrank();
+
+    // unpause BY contract
     vm.roll(block.number + 1);
-    uint256 balPre = IERC20Detailed(aToken).balanceOf(idleToken);
+    vm.prank(GUARDIAN_MULTISIG);
+    _idleToken.unpause();
+
+    // redeem with BY senior
+    // we need to check that total value of the pool is the same pre and post rebalance 
     _idleToken.rebalance();
-    // all balance is now in aave 
-    uint256 balPost = IERC20Detailed(aToken).balanceOf(idleToken);
-    // aToken price is 1, we had about 4.6M so with a tokenPrice of 0.5 we should have 2.3M
-    assertApproxEqAbs(balPost - balPre, initialContractValue / 2, 50_000 * 1e6, 'aToken bal is not half the initial val');
+    VaultDatas memory postRebalanceData = _fetchDatas(idleCDO, _idleToken, _idleTokenJunior);
+
+    assertEq(postRebalanceData.BYPriceAA, postData.BYPriceAA, 'BY AA price post rebalance changed');
+    assertEq(postRebalanceData.UserAA, postData.UserAA, 'BY AA user value post rebalance changed');
+
+    // burned all (or almost all) tranche tokens (18 decimals)
+    assertLt(IERC20Detailed(preData.AA).balanceOf(address(_idleToken)), 1e18, 'tranche tokens burned');
     // tranche price should not change
-    assertEq(idleCDO.priceAA(), redemptionRateAA, 'AA price changed');
-    assertEq(idleCDO.priceBB(), redemptionRateBB, 'BB price changed');
+    assertEq(postRebalanceData.AAPrice, postData.AAPrice, 'AA price changed');
+    assertEq(postRebalanceData.BBPrice, postData.BBPrice, 'BB price changed');
 
-    vm.clearMockedCalls();
+    if (address(_idleTokenJunior) == address(0)) {
+      return;
+    }
 
-    // We now simulate and increase in eToken price to test
-    // curr price - ~10%
-    vm.mockCall(
-      address(strategy),
-      abi.encodeWithSelector(IIdleCDOStrategy.price.selector),
-      abi.encode(9e5) // 0.9 underlyings
-    );
-
-    vm.roll(block.number + 1);
-    // test another redeem AA (we deposited 100k on setUp)
-    balPre = IERC20Detailed(UNDERLYING).balanceOf(address(this));
-    idleCDO.withdrawAA(0);
-    balPost = IERC20Detailed(UNDERLYING).balanceOf(address(this));
-    assertApproxEqAbs(balPost - balPre, 50_000 * 1e6, 5_000 * 1e6, 'underlying bal is not 0.5M');
-
-    // tranche price should not change
-    assertEq(idleCDO.priceAA(), redemptionRateAA, 'AA price changed');
-    assertEq(idleCDO.priceBB(), redemptionRateBB, 'BB price changed');
-
-    // test multiple redeem BB
-    vm.roll(block.number + 1);
+    // unpause BY
+    vm.prank(_idleTokenJunior.owner());
+    _idleTokenJunior.unpause();
 
     // redeem with BY junior
-    balPre = IERC20Detailed(maToken).balanceOf(idleTokenJunior);
+    // we need to check that total value of the pool is the same pre and post rebalance 
     _idleTokenJunior.rebalance();
-    balPost = IERC20Detailed(maToken).balanceOf(idleTokenJunior);
-    assertEq(balPost - balPre, 0, 'maToken bal diff should be 0');
+    postRebalanceData = _fetchDatas(idleCDO, _idleToken, _idleTokenJunior);
 
-    // redeem with this contract
-    balPre = IERC20Detailed(UNDERLYING).balanceOf(address(this));
-    idleCDO.withdrawBB(0);
-    balPost = IERC20Detailed(UNDERLYING).balanceOf(address(this));
-    assertEq(balPost - balPre, 0, 'juniors bal diff should be 0');
+    assertEq(postRebalanceData.BYPriceBB, postData.BYPriceBB, 'BY BB price post rebalance changed');
+    assertGe(postRebalanceData.UserBB, postData.UserBB, 'underlying BB pool value changed');
+    // burned all or almost all tranche tokens
+    assertLt(IERC20Detailed(preData.BB).balanceOf(address(_idleToken)), 1e18, 'tranche tokens burned');
+    // tranche price should not change
+    assertEq(postRebalanceData.AAPrice, postData.AAPrice, 'AA price changed');
+    assertEq(postRebalanceData.BBPrice, postData.BBPrice, 'BB price changed');
+  }
 
-    vm.clearMockedCalls();
+  function _fetchDatas(
+    IdleCDO idleCDO,
+    IdleTokenFungible _idleToken,
+    IdleTokenFungible _idleTokenJunior
+  ) internal view returns (VaultDatas memory data) {
+    data.AA = idleCDO.AATranche();
+    data.BB = idleCDO.BBTranche();
+    data.AAPrice = idleCDO.virtualPrice(data.AA);
+    data.BBPrice = idleCDO.virtualPrice(data.BB);
+    data.BYPriceAA = _idleToken.tokenPrice();
+    data.BYPriceBB = _idleTokenJunior.tokenPrice();
+    data.UserAA = IERC20Detailed(address(_idleToken)).totalSupply() * data.BYPriceAA / 1e18;
+    data.UserBB = IERC20Detailed(address(_idleTokenJunior)).totalSupply() * data.BYPriceBB / 1e18;
   }
 }


### PR DESCRIPTION
This PR won't be closed as is. This is used only to upgrade IdleCDOs affected by Euler Hack.

IdleCDO.sol was restored from commit `1957074706ce0ec2bf8ea7b92fb93c3e101f55b3` (ie remove the automatic loss mgmt as it was not audited yet).
A `setRedemptionRates` was added to distribute losses among tranche holders.
To run test comment the following files:
`test/foundry/IdleCDOLossMgmt.t.sol`
`test/foundry/IdleLeveragedEulerStrategy.t.sol`