### PR TITLE
Reduce complexity

### DIFF
--- a/contracts/strategies/morpho/MetaMorphoStrategy.sol
+++ b/contracts/strategies/morpho/MetaMorphoStrategy.sol
@@ -285,7 +285,7 @@ contract MetaMorphoStrategy is ERC4626Strategy {
       // calc how much of `sub` will be removed from this market
       uint256 _toSub;
       if (_aprData.sub > 0) {
-        (_toSub, _aprData.sub) -= _calcMarketSub(_mmVault, _marketId, _aprData.sub);
+        (_toSub, _aprData.sub) = _calcMarketSub(_mmVault, _marketId, _aprData.sub);
       }
       // get underlyings supplied by the vault in the target market
       // totalSupplyShares : totalSupplyAssets = supplyShares : assetsSuppliedByVault
@@ -383,7 +383,7 @@ contract MetaMorphoStrategy is ERC4626Strategy {
     uint256 _withdrawable = _vaultAssets > _availableLiquidity ? _vaultAssets : _availableLiquidity;
 
     if (_sub > _withdrawable) {
-      (toSub, remaining) = (_withdrawable, _sub - remaining);
+      (toSub, remaining) = (_withdrawable, _sub - _withdrawable);
     } else {
       (toSub, remaining) = (_sub, 0);
     }


### PR DESCRIPTION
I think this works : we only loop one through the withdraw queue, and for each market

I realized there was another problem in the code : in `_calcMarketSub`, the amount that can be withdrawn from a market is considered to be the available liquidity of the market. But actually it is the minimum between the liquidity of the market and the assets supplied by the vault in the market.

I fixed it quickly but without taking into both the accrued interest (since the last interaction with the vault) and the virtual shares/assets

A better fix would be to import the Morpho libraries : min(availableLiquidity, ) but it would require using the MorphoBalanceLib.

What do you think about this ?