### PR TITLE
FIX: move the burn of MIN_LIQUIDITY on first deposit to the IdleCDOTr…

### DIFF
--- a/contracts/IdleCDO.sol
+++ b/contracts/IdleCDO.sol
@@ -464,12 +464,6 @@ contract IdleCDO is PausableUpgradeable, GuardedLaunchUpgradable, IdleCDOStorage
     IdleCDOTranche tr = IdleCDOTranche(_tranche);
     // calculate # of tranche token to mint based on current tranche price: _amount / tranchePrice
     _minted = _amount * ONE_TRANCHE_TOKEN / _tranchePrice(_tranche);
-    // burn MIN_LIQUIDITY on first tranche deposit
-    if (tr.totalSupply() == 0) {
-      require(_amount >= MIN_LIQUIDITY, '5');
-      tr.mint(address(1), MIN_LIQUIDITY);
-      _minted = _minted - MIN_LIQUIDITY;
-    }
     tr.mint(_to, _minted);
     // update NAV with the _amount of underlyings added
     if (_tranche == AATranche) {

--- a/contracts/IdleCDOTranche.sol
+++ b/contracts/IdleCDOTranche.sol
@@ -7,6 +7,8 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 contract IdleCDOTranche is ERC20 {
   // allowed minter address
   address public minter;
+  // liquidity burned at first tranche deposit
+  uint256 internal constant MIN_LIQUIDITY = 10**3;
 
   /// @param _name tranche name
   /// @param _symbol tranche symbol
@@ -21,14 +23,19 @@ contract IdleCDOTranche is ERC20 {
   /// @param account that should receive the tranche tokens
   /// @param amount of tranche tokens to mint
   function mint(address account, uint256 amount) external {
-    require(msg.sender == minter, 'TRANCHE:!AUTH');
+    require(msg.sender == minter, '6');
+    // burn MIN_LIQUIDITY on first tranche deposit
+    if (totalSupply() == 0) {
+      _mint(address(1), MIN_LIQUIDITY);
+      amount -= MIN_LIQUIDITY;
+    }
     _mint(account, amount);
   }
 
   /// @param account that should have the tranche tokens burned
   /// @param amount of tranche tokens to burn
   function burn(address account, uint256 amount) external {
-    require(msg.sender == minter, 'TRANCHE:!AUTH');
+    require(msg.sender == minter, '6');
     _burn(account, amount);
   }
 }

--- a/test/foundry/AmphorStrategy.t.sol
+++ b/test/foundry/AmphorStrategy.t.sol
@@ -111,6 +111,7 @@ contract TestAmphorStrategy is TestIdleCDOLossMgmt {
   function testCannotRedeemWhenEpochRunning() external {
     uint256 amount = 1 * ONE_SCALE;
     idleCDO.depositAA(amount);
+    _transferBurnedTrancheTokens(address(this), true);
     vm.roll(block.number + 1);
     _toggleEpoch(true, 0);
 
@@ -210,6 +211,7 @@ contract TestAmphorStrategy is TestIdleCDOLossMgmt {
     uint256 priceAAPre = idleCDO.virtualPrice(address(AAtranche));
     // try to deposit the correct bal
     idleCDO.depositAA(_val);
+    _transferBurnedTrancheTokens(address(this), true);
     assertApproxEqAbs(
       IERC20Detailed(address(AAtranche)).balanceOf(address(this)), 
       scaledVal, 

--- a/test/foundry/IdleCreditVault.t.sol
+++ b/test/foundry/IdleCreditVault.t.sol
@@ -210,6 +210,8 @@ contract TestIdleCreditVault is TestIdleCDOLossMgmt {
     uint256 amount = 1 * ONE_SCALE;
     uint256 mintedAA = idleCDO.depositAA(amount);
     uint256 mintedBB = idleCDO.depositBB(amount);
+    _transferBurnedTrancheTokens(address(this), true);
+    _transferBurnedTrancheTokens(address(this), false);
     vm.roll(block.number + 1);
 
     // start epoch
@@ -925,8 +927,6 @@ contract TestIdleCreditVault is TestIdleCDOLossMgmt {
     uint256 mintedBB = idleCDO.depositBB(amountWei);
     _transferBurnedTrancheTokens(address(this), true);
     _transferBurnedTrancheTokens(address(this), false);
-    mintedAA += 10**3;
-    mintedBB += 10**3;
 
     // start epoch
     _startEpochAndCheckPrices(0);
@@ -1930,7 +1930,7 @@ contract TestIdleCreditVault is TestIdleCDOLossMgmt {
 
     // contract value will be eq to 
     // initial amount - requested amount + interest for the epoch + interest for pending withdraw
-    assertEq(cdoEpoch.getContractValue(), amount - interest + cdoEpoch.lastEpochInterest() + interestPendingWithdraw, 'contract value is wrong');
+    assertApproxEqAbs(cdoEpoch.getContractValue(), amount - interest + cdoEpoch.lastEpochInterest() + interestPendingWithdraw, 1, 'contract value is wrong');
   }
 
   function testClosePool() external {

--- a/test/foundry/IdleLeveragedEulerStrategy.t.sol
+++ b/test/foundry/IdleLeveragedEulerStrategy.t.sol
@@ -130,6 +130,8 @@ contract TestIdleEulerLeveragedStrategy is TestIdleCDOBase {
         uint256 balBefor1 = underlying.balanceOf(address(1));
         idleCDO.depositAA(amount);
         idleCDO.depositBB(amount);
+        _transferBurnedTrancheTokens(address(this), true);
+        _transferBurnedTrancheTokens(address(this), false);
         uint256 aaBal = IERC20Detailed(address(AAtranche)).balanceOf(address(this));
         uint256 bbBal = IERC20Detailed(address(BBtranche)).balanceOf(address(this));
         uint256 pricePre = strategy.price();


### PR DESCRIPTION
…anche contract

The PR was initially created here https://github.com/Idle-Labs/idle-tranches/pull/96 and the implementation is now updated and the burn of the min liquidity moved from `IdleCDO.sol` to `IdleCDOTranche.sol`. This is done to reduce IdleCDO bytecode size mainly.